### PR TITLE
chore: add newpkg script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,13 @@
 	"scripts": {
 		"build": "lerna --ignore @styocss/docs run build",
 		"stub": "lerna --ignore @styocss/docs run stub",
+		"newpkg": "tsx ./scripts/newpkg.ts",
 		"prepare:local": "pnpm build && tsx ./scripts/prepareLocalInstall.ts",
 		"publint": "lerna --ignore @styocss/docs exec publint",
 		"release": "pnpm build && pnpm docs:build && pnpm typecheck && pnpm publint && lerna publish",
-
 		"docs:dev": "lerna --scope @styocss/docs run dev",
 		"docs:build": "lerna --scope @styocss/docs run build",
 		"docs:preview": "lerna --scope @styocss/docs run preview",
-
 		"typecheck": "lerna run typecheck",
 		"test": "vitest",
 		"test:coverage": "vitest --coverage",
@@ -31,6 +30,7 @@
 		"prepare": "simple-git-hooks"
 	},
 	"devDependencies": {
+		"@clack/prompts": "catalog:",
 		"@deviltea/eslint-config": "catalog:",
 		"@deviltea/tsconfig": "catalog:",
 		"@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@clack/prompts':
+      specifier: 0.10.0
+      version: 0.10.0
     '@deviltea/eslint-config':
       specifier: 3.4.1
       version: 3.4.1
@@ -110,6 +113,9 @@ importers:
 
   .:
     devDependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 0.10.0
       '@deviltea/eslint-config':
         specifier: 'catalog:'
         version: 3.4.1(@vue/compiler-sfc@3.5.13)(eslint@9.13.0(jiti@2.4.2))(typescript@5.6.3)(vitest@3.0.3(@types/node@20.0.0)(happy-dom@15.7.4)(terser@5.36.0))
@@ -477,6 +483,12 @@ packages:
 
   '@clack/core@0.3.4':
     resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
+
+  '@clack/core@0.4.1':
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+
+  '@clack/prompts@0.10.0':
+    resolution: {integrity: sha512-H3rCl6CwW1NdQt9rE3n373t7o5cthPv7yUoxF2ytZvyvlJv89C5RYMJu83Hed8ODgys5vpBU0GKxIRG83jd8NQ==}
 
   '@clack/prompts@0.7.0':
     resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
@@ -5805,6 +5817,17 @@ snapshots:
 
   '@clack/core@0.3.4':
     dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/core@0.4.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.10.0':
+    dependencies:
+      '@clack/core': 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - 'packages/*'
 
 catalog:
+  '@clack/prompts': 0.10.0
   '@deviltea/eslint-config': 3.4.1
   '@deviltea/tsconfig': 0.0.6
   '@nuxt/kit': ^3.0.0

--- a/scripts/newpkg.ts
+++ b/scripts/newpkg.ts
@@ -1,0 +1,176 @@
+import process from 'node:process'
+import { writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { cancel, intro, isCancel, outro, text } from '@clack/prompts'
+import { join } from 'pathe'
+import { $ } from 'zx'
+
+intro('Create a new package')
+
+const pkgDirname = await text({
+	message: 'Package directory name (/packages/<pkgDirname>)',
+	validate: (value) => {
+		if (!value)
+			return 'Required.'
+		if (!/^[a-z0-9-]+$/.test(value))
+			return 'Only lowercase letters, numbers, and hyphens are allowed.'
+		return void 0
+	},
+})
+
+if (isCancel(pkgDirname)) {
+	cancel('Operation cancelled.')
+	process.exit(0)
+}
+
+const pkgName = await text({
+	message: 'Package name (@styocss/<pkgName>)',
+	initialValue: pkgDirname,
+	validate: (value) => {
+		if (!value)
+			return 'Required.'
+		if (!/^[a-z0-9-]+$/.test(value))
+			return 'Only lowercase letters, numbers, and hyphens are allowed.'
+		return void 0
+	},
+})
+
+if (isCancel(pkgName)) {
+	cancel('Operation cancelled.')
+	process.exit(0)
+}
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const packageDir = join(root, 'packages', pkgDirname)
+
+await $`(rm -rf ${packageDir} || true) \
+		&& mkdir -p ${packageDir} \
+		&& mkdir -p ${join(packageDir, 'src')} \
+		&& mkdir -p ${join(packageDir, 'tests')} \
+`
+
+const pkgJson = JSON.parse((await $`cat ${join(root, 'package.json')}`).stdout)
+
+const templates = {
+	'package.json': `
+{
+	"name": "@styocss/${pkgName}",
+	"type": "module",
+	"publishConfig": {
+		"access": "public"
+	},
+	"version": "${pkgJson.version}",
+	"author": "DevilTea <ch19980814@gmail.com>",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/DevilTea/styocss.git",
+		"directory": "packages/${pkgDirname}"
+	},
+	"bugs": {
+		"url": "https://github.com/DevilTea/styocss/issues"
+	},
+	"keywords": [],
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
+		}
+	},
+	"main": "dist/index.cjs",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "unbuild",
+		"build:pack": "pnpm build && pnpm pack",
+		"stub": "unbuild --stub",
+		"typecheck": "pnpm typecheck:package && pnpm typecheck:test",
+		"typecheck:package": "tsc --project ./tsconfig.package.json --noEmit",
+		"typecheck:test": "tsc --project ./tsconfig.tests.json --noEmit"
+	}
+}
+	`.trim(),
+	'build.config.ts': `
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+	entries: ['src/index.ts'],
+	declaration: true,
+	rollup: {
+		dts: {
+			tsconfig: './tsconfig.package.json',
+			compilerOptions: {
+				composite: false,
+			},
+		},
+		emitCJS: true,
+	},
+})
+	`.trim(),
+	'src/index.ts': `
+export {}
+	`.trim(),
+	'tests/some.test.ts': `
+import { describe, expect, it } from 'vitest'
+
+describe('hello', () => {
+	it('is ok', () => {
+		expect(true).toBe(true)
+	})
+})
+	`.trim(),
+	'tsconfig.json': `
+{
+	"references": [
+		{ "path": "./tsconfig.package.json" },
+		{ "path": "./tsconfig.tests.json" }
+	],
+	"files": []
+}
+	`.trim(),
+	'tsconfig.package.json': `
+{
+	"extends": "@deviltea/tsconfig/base",
+	"compilerOptions": {
+		"composite": true
+	},
+	"include": [
+		"./src/**/*.ts"
+	]
+}
+	`.trim(),
+	'tsconfig.tests.json': `
+{
+	"extends": "@deviltea/tsconfig/node",
+	"compilerOptions": {
+		"composite": true
+	},
+	"include": [
+		"./src/**/*.ts",
+		"./tests/**/*.ts"
+	]
+}
+	`.trim(),
+}
+
+for (const [filename, content] of Object.entries(templates)) {
+	await writeFile(join(packageDir, filename), `${content}\n`)
+}
+
+const rootTsConfig = JSON.parse((await $`cat ${join(root, 'tsconfig.json')}`).stdout)
+const pkgTsConfigPath = `./packages/${pkgDirname}/tsconfig.json`
+if (rootTsConfig.extends.includes(pkgTsConfigPath) === false) {
+	rootTsConfig.extends.push(pkgTsConfigPath)
+	await writeFile(join(root, 'tsconfig.json'), `${JSON.stringify(rootTsConfig, null, '\t')}\n`)
+}
+
+outro(`Package "${pkgName}" created.`)


### PR DESCRIPTION
This pull request introduces a new package creation script and updates dependencies to include the `@clack/prompts` library. The most important changes are summarized below.

### New Feature:
* Added a new script `newpkg` to the `package.json` file for creating new packages (`package.json`: [package.jsonR19-R33](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R33)).
* Implemented the `scripts/newpkg.ts` script to automate the creation of new packages with predefined templates (`scripts/newpkg.ts`: [scripts/newpkg.tsR1-R176](diffhunk://#diff-282bc76c8f5c334fd6a0a61b505f7c584143ba554099aaa282115c62ce46f947R1-R176)).

### Dependency Updates:
* Added `@clack/prompts` as a development dependency in `package.json` (`package.json`: [package.jsonR19-R33](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19-R33)).
* Updated `pnpm-lock.yaml` to include `@clack/prompts` version 0.10.0 in the `catalogs`, `importers`, `packages`, and `snapshots` sections (`pnpm-lock.yaml`: [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9-R11) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR116-R118) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR487-R492) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5823-R5833).
* Updated `pnpm-workspace.yaml` to include `@clack/prompts` version 0.10.0 in the `catalog` section (`pnpm-workspace.yaml`: [pnpm-workspace.yamlR6](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cR6)).