### PR TITLE
ci: archive repopack output for release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
     # Gate publishing behind a GitHub Environment so a maintainer can require
     # manual approval and restrict which refs may release. Add "Required
     # reviewers"/branch protection to this environment in the repo settings;
@@ -46,10 +48,14 @@ jobs:
         run: pnpm build && pnpm publint && pnpm attw && pnpm typecheck && pnpm test
 
       - name: bump version
+        id: bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           pnpm exec bumpp -r ${{ github.event.inputs.bump_type }} -y
+
+          tag="$(git describe --tags --exact-match HEAD)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: publish (npm trusted publishing)
         run: pnpm build && pnpm publish:packages
@@ -59,3 +65,10 @@ jobs:
         run: pnpm exec changelogithub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  repopack:
+    name: Generate repopack artifact
+    needs: release
+    uses: ./.github/workflows/repopack.yml
+    with:
+      ref: ${{ needs.release.outputs.tag }}

--- a/.github/workflows/repopack.yml
+++ b/.github/workflows/repopack.yml
@@ -1,0 +1,70 @@
+name: Repopack
+
+permissions:
+  contents: read
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+  workflow_call:
+    inputs:
+      ref:
+        description: Version tag to pack
+        required: true
+        type: string
+
+jobs:
+  repopack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: resolve release tag
+        id: release
+        env:
+          TARGET_REF: ${{ github.event_name == 'push' && github.ref_name || inputs.ref }}
+        run: |
+          if [[ ! "$TARGET_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::'$TARGET_REF' is not a semantic version tag prefixed with v."
+            exit 1
+          fi
+
+          echo "tag=$TARGET_REF" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=repopack-$TARGET_REF" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 0
+
+      - name: verify tag belongs to main
+        env:
+          TARGET_REF: ${{ steps.release.outputs.tag }}
+        run: |
+          git fetch origin main:refs/remotes/origin/main --no-tags
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/main; then
+            echo "::error::Tag '$TARGET_REF' does not point to a commit contained in main."
+            exit 1
+          fi
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: generate repopack files
+        run: pnpm repopack
+
+      - name: upload repopack artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.release.outputs.artifact_name }}
+          path: repomix/*.txt
+          if-no-files-found: error
+          compression-level: 9


### PR DESCRIPTION
## Summary

- add a reusable `Repopack` workflow that runs for semantic-version tags prefixed with `v`
- verify the tagged commit is contained in `main`
- run `pnpm repopack` and upload all `repomix/*.txt` files as a single versioned artifact
- call the reusable workflow explicitly after the existing `Release` job succeeds

## Why

The release workflow pushes its version commit and tag with the repository `GITHUB_TOKEN`. GitHub intentionally prevents events generated by that token from starting another workflow, so a tag-only trigger would not run during the current automated release flow. The explicit reusable-workflow call preserves normal tag-push support while guaranteeing artifacts for releases created by the existing workflow.

## Validation

- matched the repository's pinned checkout, pnpm setup, and Node setup actions
- pinned `actions/upload-artifact` to v7.0.1
- configured `if-no-files-found: error`
- limited permissions to `contents: read` in the repopack workflow
- reviewed the resulting workflow YAML and branch diff

The workflow itself requires a real release tag to exercise end-to-end, so this PR does not create a test tag.