### PR TITLE
docs(skill): refresh pikacss-use for current APIs

### DIFF
--- a/docs/integrations/agent-skills.md
+++ b/docs/integrations/agent-skills.md
@@ -3,7 +3,11 @@ title: Agent Skills
 description: AI-assisted development skill for using and extending PikaCSS.
 relatedPackages:
   - '@pikacss/core'
-relatedSources: []
+  - '@pikacss/unplugin-pikacss'
+  - '@pikacss/plugin-icons'
+  - '@pikacss/plugin-design-tokens'
+relatedSources:
+  - 'skills/pikacss-use/SKILL.md'
 category: integrations
 order: 30
 ---
@@ -25,13 +29,15 @@ npx skills add pikacss/pikacss --skill pikacss-use
 Use this skill when you are working with PikaCSS in any capacity:
 
 - Setting up PikaCSS in a new project
-- Configuring engine options or build plugins
+- Configuring engine options or build integrations
 - Using `pika()` and its variants
-- Consuming official plugins (reset, icons, fonts, typography)
-- Troubleshooting build or runtime issues
+- Consuming official plugins (reset, icons, fonts, typography, and design tokens)
+- Troubleshooting transforms, generated files, TypeScript declarations, or configuration reloads
+- Choosing neutral or Node.js runtime adapters for plugins that load local resources
 - Creating a new engine plugin from scratch
-- Implementing plugin hooks and lifecycle
+- Implementing plugin hooks, structured diagnostics, and lifecycle behavior
 - Extending `EngineConfig` with module augmentation
+- Registering external configuration dependencies for file watching
 - Writing plugin tests
 
 ### How to Trigger
@@ -40,18 +46,22 @@ The skill is automatically activated when your question relates to PikaCSS usage
 
 ### Coverage
 
-- Installation and build tool integration (Vite, Webpack, Nuxt, etc.)
+- Installation and build tool integration (Vite, Webpack, Rollup, esbuild, Rspack, Rolldown, and Nuxt)
+- Node.js, Vite, source-file, and static-analysis compatibility constraints
 - Engine configuration and customization
+- Generated CSS and TypeScript declaration files
 - The `pika()`, `pika.str()`, `pika.arr()`, and `pikap()` functions
 - Official plugin consumption and configuration
+- Neutral and Node.js plugin entry points
 - ESLint integration
 - TypeScript autocomplete support
 - Plugin structure and `defineEnginePlugin`
-- Lifecycle hooks and execution order
+- Lifecycle hooks, hook context, diagnostics, and execution order
 - Config augmentation via TypeScript module augmentation
 - Layer management and preflight injection
-- Selector, shortcut, variable, and keyframe registration
-- Plugin testing patterns
+- Selector, shortcut, variable, keyframe, and design-token registration
+- External config dependency watching
+- Plugin testing patterns using `createEngine`
 
 ## Next
 

--- a/docs/zh-tw/integrations/agent-skills.md
+++ b/docs/zh-tw/integrations/agent-skills.md
@@ -3,18 +3,22 @@ title: Agent Skills
 description: 用於使用與擴充 PikaCSS 的 AI 輔助開發 skill。
 relatedPackages:
   - '@pikacss/core'
-relatedSources: []
+  - '@pikacss/unplugin-pikacss'
+  - '@pikacss/plugin-icons'
+  - '@pikacss/plugin-design-tokens'
+relatedSources:
+  - 'skills/pikacss-use/SKILL.md'
 category: integrations
 order: 30
 translation:
   sourceFile: docs/integrations/agent-skills.md
-  sourceCommit: ee25703206bb11f86a899f6e9673250ddabc235c
-  sourceBlob: 847588889e7f5698fc724e8a4931657cfa635e74
+  sourceCommit: f0d80ceeb45331b70fcfa086aeebcacfdb5a3f8e
+  sourceBlob: 226d1207375d476f81c5e53f64114fd864848557
 ---
 
 # Agent Skills {#agent-skills}
 
-PikaCSS 內建了一個 agent skill，為使用與擴充 PikaCSS 兩方面都提供 AI 輔助的指引。你可以用 [`skills` CLI](https://www.npmjs.com/package/skills) 安裝它，在任何支援的 coding agent 中使用。
+PikaCSS 內建了一個 agent skill，為使用與擴充 PikaCSS 兩方面都提供 AI 輔助指引。你可以用 [`skills` CLI](https://www.npmjs.com/package/skills) 安裝它，並在任何支援的 coding agent 中使用。
 
 ## 安裝 {#install}
 
@@ -26,38 +30,44 @@ npx skills add pikacss/pikacss --skill pikacss-use
 
 ### 何時使用 {#when-to-use}
 
-當你以任何形式使用 PikaCSS 時，都可以使用這個 skill：
+只要正在處理 PikaCSS，就可以使用這個 skill：
 
 - 在新專案中設定 PikaCSS
-- 設定引擎選項或建置外掛
+- 設定引擎選項或建置工具整合
 - 使用 `pika()` 及其變體
-- 使用官方外掛（reset、icons、fonts、typography）
-- 排解建置或執行階段的問題
-- 從頭建立一個新的引擎外掛
-- 實作外掛的 hook 與生命週期
+- 使用官方外掛（reset、icons、fonts、typography 與 design tokens）
+- 排查轉換、產生檔案、TypeScript 宣告或設定重新載入問題
+- 為會載入本機資源的外掛選擇中立或 Node.js 執行階段 adapter
+- 從頭建立新的引擎外掛
+- 實作外掛 hook、結構化 diagnostic 與生命週期行為
 - 透過模組擴增來擴充 `EngineConfig`
-- 撰寫外掛的測試
+- 註冊外部設定相依檔案，以供檔案監看
+- 撰寫外掛測試
 
 ### 如何觸發 {#how-to-trigger}
 
-當你的問題與 PikaCSS 的使用或外掛開發相關時，這個 skill 會自動啟用。你也可以在你的 prompt 中明確提到「using PikaCSS」、「PikaCSS setup」，或「PikaCSS plugin development」。
+當問題與 PikaCSS 的使用或外掛開發相關時，這個 skill 會自動啟用。你也可以在 prompt 中明確提到「using PikaCSS」、「PikaCSS setup」或「PikaCSS plugin development」。
 
 ### 涵蓋範圍 {#coverage}
 
-- 安裝與建置工具整合（Vite、Webpack、Nuxt 等）
+- 安裝與建置工具整合（Vite、Webpack、Rollup、esbuild、Rspack、Rolldown 與 Nuxt）
+- Node.js、Vite、來源檔案與靜態分析相容性限制
 - 引擎設定與客製化
-- `pika()`、`pika.str()`、`pika.arr()`，以及 `pikap()` 函式
+- 產生的 CSS 與 TypeScript 宣告檔案
+- `pika()`、`pika.str()`、`pika.arr()` 與 `pikap()` 函式
 - 官方外掛的使用與設定
+- 中立與 Node.js 外掛進入點
 - ESLint 整合
 - TypeScript 自動完成支援
 - 外掛結構與 `defineEnginePlugin`
-- 生命週期 hook 與執行順序
+- 生命週期 hook、hook context、diagnostic 與執行順序
 - 透過 TypeScript 模組擴增來擴充設定
 - layer 管理與 preflight 注入
-- 選擇器、shortcut、變數，以及關鍵影格的註冊
-- 外掛測試的模式
+- selector、shortcut、變數、關鍵影格與 design token 的註冊
+- 外部設定相依檔案的監看
+- 使用 `createEngine` 的外掛測試模式
 
 ## 下一步 {#next}
 
 - [安裝與設定](/zh-tw/getting-started/setup)：在你的專案中安裝 PikaCSS。
-- [外掛開發](/zh-tw/plugin-development/create-a-plugin)：建立你自己的外掛。
+- [外掛開發](/zh-tw/plugin-development/create-a-plugin)：建立自己的外掛。

--- a/docs/zh-tw/integrations/agent-skills.md
+++ b/docs/zh-tw/integrations/agent-skills.md
@@ -36,7 +36,7 @@ npx skills add pikacss/pikacss --skill pikacss-use
 - 設定引擎選項或建置工具整合
 - 使用 `pika()` 及其變體
 - 使用官方外掛（reset、icons、fonts、typography 與 design tokens）
-- 排查轉換、產生檔案、TypeScript 宣告或設定重新載入問題
+- 排解轉換、產生檔案、TypeScript 宣告或設定重新載入問題
 - 為會載入本機資源的外掛選擇中立或 Node.js 執行階段 adapter
 - 從頭建立新的引擎外掛
 - 實作外掛 hook、結構化 diagnostic 與生命週期行為

--- a/skills/pikacss-use/SKILL.md
+++ b/skills/pikacss-use/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pikacss-use
-description: 'Use when working with PikaCSS — the atomic CSS-in-JS engine. Covers both consumer usage and plugin authoring. Consumer: installation, Vite/Nuxt/Webpack/Rollup/esbuild/Rspack integration, pika.config setup, pika() compile-time macro, official plugins (reset, icons, fonts, typography), ESLint, TypeScript, Vite integration behavior, variables/selectors/shortcuts/keyframes/preflights. Plugin author: defineEnginePlugin, lifecycle hooks (configureRawConfig, configureEngine, transformStyleItems), EngineConfig module augmentation, engine API, testing with createEngine. Use when: setting up PikaCSS, configuring pika.config, using pika()/pikap(), troubleshooting build errors, creating or modifying plugins, understanding hooks or config augmentation. Trigger on mentions of PikaCSS, pika(), defineEnginePlugin, plugin hooks, or configureEngine.'
+description: 'Use when working with PikaCSS, the build-time atomic CSS-in-JS engine. Covers consumer setup, Vite/Nuxt/Webpack/Rollup/esbuild/Rspack/Rolldown integration, pika.config, pika()/pikap(), generated CSS and TypeScript declarations, selectors, shortcuts, variables, keyframes, preflights, official plugins (reset, icons, fonts, typography, design tokens), ESLint, troubleshooting, and plugin authoring with defineEnginePlugin, lifecycle hooks, diagnostics, runtime adapters, EngineConfig augmentation, engine APIs, and createEngine tests. Trigger on PikaCSS, pika(), pikap(), defineEnginePlugin, plugin hooks, or PikaCSS configuration.'
 ---
 
 # Use PikaCSS
 
-PikaCSS is an instant on-demand atomic CSS-in-JS engine. It generates atomic CSS at **build time** by transforming `pika()` calls in source code into class-name literals. Build-tool plugins handle the transformation, CSS generation, and TypeScript declaration output.
+PikaCSS is an instant on-demand atomic CSS-in-JS engine. It transforms statically analyzable `pika()` calls into class-name literals at build time, emits the matching atomic CSS, and generates TypeScript declarations for the compile-time globals.
 
 - **Docs**: <https://pikacss.github.io/getting-started/>
 - **API Reference**: <https://pikacss.github.io/api/>
@@ -13,47 +13,68 @@ PikaCSS is an instant on-demand atomic CSS-in-JS engine. It generates atomic CSS
 
 ## Reference Files
 
-This skill ships with detailed reference documents. Load them on demand:
+Load the smallest relevant reference instead of guessing from memory:
 
 | File | When to read |
 |---|---|
-| `references/build-options.md` | User asks about build plugin options — scan patterns, output format, codegen paths, custom function name, HMR |
-| `references/customizations.md` | User asks about variables (theming/dark mode), keyframes, preflights, selectors config, shortcuts with nested selectors, `__layer`/`__important`, CSS property syntax, or `define*` helpers |
-| `references/plugin-reset.md` | User asks about CSS reset plugin — choosing a reset style |
-| `references/plugin-icons.md` | User asks about icon shortcuts, Iconify collections, or icon troubleshooting |
-| `references/plugin-fonts.md` | User asks about web font loading — Google Fonts, `@font-face`, or `@import` |
-| `references/plugin-typography.md` | User asks about prose/typography shortcuts or `--pk-prose-*` variables |
-| `references/plugin-development.md` | User asks about creating a plugin, plugin hooks, lifecycle, engine API, config augmentation, or plugin testing |
+| `references/build-options.md` | Build plugin options, scan patterns, codegen paths, custom function names, bundler roots, or HMR |
+| `references/customizations.md` | Variables, theming, keyframes, preflights, selectors, shortcuts, `__shortcut`, `__layer`, `__important`, CSS value fallbacks, or typed config fragments |
+| `references/plugin-reset.md` | Choosing and configuring a reset style |
+| `references/plugin-icons.md` | Icon shortcuts, Iconify collections, Node versus neutral adapters, processor metadata, or icon troubleshooting |
+| `references/plugin-fonts.md` | Google Fonts, `@font-face`, `@import`, font families, or providers |
+| `references/plugin-typography.md` | Prose shortcuts and `--pk-prose-*` variables |
+| `references/plugin-design-tokens.md` | Inline or file-backed design tokens, W3C token JSON, `design.md`, themes, aliases, pruning, or runtime adapters |
+| `references/plugin-development.md` | Creating plugins, lifecycle hooks, diagnostics, engine APIs, config augmentation, external file dependencies, or testing |
 
-## Key Concept — pika() Is a Compile-Time Macro
+## Non-Negotiable Facts
 
-`pika()` is **not** a runtime function. The build plugin scans source files, evaluates each `pika()` call at build time, and replaces it with a string literal (or array literal) of generated class names. No PikaCSS code runs in the browser. This means:
+- PikaCSS packages require **Node.js 22 or later**.
+- The Vite adapter supports **Vite 7 and 8** (`^7.0.0 || ^8.0.0`).
+- `pika` and `pikap` are generated compile-time globals. **Never import them.**
+- Arguments must be statically analyzable. Runtime values belong in CSS variables, variant maps, or predefined shortcuts.
+- The built-in AST processors support the JS family (`js`, `mjs`, `cjs`, `jsx`, `ts`, `mts`, `cts`, `tsx`) and Vue SFCs. Do not claim Svelte, Astro, or plain HTML source transforms are supported.
+- Config discovery is project-root-only. Generated declaration files must be included in the TypeScript program.
 
-- `pika({ display: 'flex' })` becomes `'pk-a1b2'` (a plain string) in the built output.
-- The corresponding CSS rule `.pk-a1b2 { display: flex }` is emitted into the generated CSS file.
-- Arguments to `pika()` must be statically analyzable — no runtime variables.
+## How the Compile-Time Macro Works
 
-## Boundary
+```ts
+const className = pika({ display: 'flex', color: 'red' })
+```
 
-- This skill covers both consumer usage (install, configure, troubleshoot) and plugin authoring (create, modify, test plugins).
-- This is a skill-only domain guide. The main agent should apply it directly instead of delegating to a same-named custom agent.
-- Official plugins are in scope both as things to consume and as reference implementations for plugin authors.
-- For plugin authoring details (hooks, engine API, config augmentation, testing), load `references/plugin-development.md`.
+is transformed into a plain literal such as:
 
-## Agent pairing
+```ts
+const className = 'pk-a1b2 pk-c3d4'
+```
 
-- Dedicated implementation agent: none
-- Dedicated review agent: none
-- Use this skill directly in the main conversation for consumer-facing setup and troubleshooting.
+The generated CSS contains the corresponding atomic rules. No PikaCSS runtime is shipped to the browser.
 
 ## Installation
 
+### Vite and other unplugin integrations
+
 ```bash
-pnpm add -D @pikacss/unplugin-pikacss           # Core + build plugin (Vite/Webpack/Rollup/etc.)
-# pnpm add -D @pikacss/nuxt-pikacss             # Nuxt module (includes Vite plugin)
-# pnpm add -D @pikacss/plugin-{reset,icons,fonts,typography}  # Official plugins
-# pnpm add -D @pikacss/eslint-config             # ESLint config
+pnpm add -D @pikacss/core @pikacss/unplugin-pikacss
 ```
+
+### Nuxt
+
+```bash
+pnpm add -D @pikacss/core @pikacss/nuxt-pikacss
+```
+
+### Optional packages
+
+```bash
+pnpm add -D @pikacss/plugin-reset
+pnpm add -D @pikacss/plugin-icons
+pnpm add -D @pikacss/plugin-fonts
+pnpm add -D @pikacss/plugin-typography
+pnpm add -D @pikacss/plugin-design-tokens
+pnpm add -D @pikacss/eslint-config
+```
+
+Install `@pikacss/core` directly because application config files and official plugins consume its public types and helpers.
 
 ## Build Plugin Setup
 
@@ -69,9 +90,9 @@ export default defineConfig({
 })
 ```
 
-### Other Bundlers
+The Vite adapter uses `enforce: 'pre'`, so `[vue(), pikacss()]` is supported even though listing PikaCSS first remains clearer.
 
-`@pikacss/unplugin-pikacss` provides subpath exports for every supported bundler:
+### Other bundlers
 
 | Bundler | Import path |
 |---|---|
@@ -82,7 +103,7 @@ export default defineConfig({
 | Rspack | `@pikacss/unplugin-pikacss/rspack` |
 | Rolldown | `@pikacss/unplugin-pikacss/rolldown` |
 
-Each export is a factory function: `import pikacss from '@pikacss/unplugin-pikacss/<bundler>'`, then add `pikacss()` to the bundler's plugin array. See `references/build-options.md` for all plugin options.
+Each subpath exports a plugin factory. Add `pikacss()` to the target bundler's plugin array. Read `references/build-options.md` before recommending non-default options.
 
 ### Nuxt
 
@@ -93,53 +114,57 @@ export default defineNuxtConfig({
 })
 ```
 
-In Nuxt projects, use `@pikacss/nuxt-pikacss` instead of manually adding `@pikacss/unplugin-pikacss/vite` to `vite.plugins`. The Nuxt module owns that wiring, configures the Vite plugin internally, and injects a generated Nuxt plugin/template that imports `pika.css` automatically, so no manual CSS import is needed.
+Do not also add `@pikacss/unplugin-pikacss/vite`. The Nuxt module owns the Vite wiring and imports `pika.css` through a generated Nuxt plugin/template.
 
-### Generated Files and CSS Import
+## Generated Files and CSS Import
 
-The build plugin generates two files (configurable via plugin options):
-- `pika.gen.css` — all atomic CSS rules
-- `pika.gen.ts` — TypeScript declarations for `pika()` and `pikap()`
+The build integration writes:
 
-**Import the CSS via the `pika.css` virtual module** in your entry file:
+- `pika.gen.css` by default. CSS codegen is required, although the path is configurable.
+- `pika.gen.ts` by default. TypeScript codegen may be redirected or disabled.
+- `pika.config.js` only when `autoCreateConfig: true`; the default is `false`.
+
+For non-Nuxt applications, import the virtual CSS module in the entry file:
 
 ```ts
-// main.ts (Vite/Webpack/etc. — not needed for Nuxt)
 import 'pika.css'
 ```
 
-`pika.css` is a virtual module alias that resolves to the generated CSS file. In Nuxt, the module-generated plugin/template handles this import automatically.
+The virtual module follows a custom `cssCodegen` path automatically.
 
-### TypeScript — pika.gen.ts Must Be Included
+### TypeScript inclusion
 
-`pika.gen.ts` provides type declarations that make `pika()` and `pikap()` available as global compile-time macros. **It must be visible to the TypeScript compiler**, otherwise you will get "Cannot find name 'pika'" errors.
+A root-level `pika.gen.ts` is not included by scaffolded projects whose tsconfig only includes `src`. Prefer either:
 
-There are two ways it can be included:
+```ts
+// vite.config.ts
+pikacss({ tsCodegen: './src/pika.gen.ts' })
+```
 
-1. **Implicit inclusion** — If your `tsconfig.json` uses a broad `include` pattern that already covers the project root (e.g. `"include": ["src", "."]` or `"include": ["**/*.ts"]`), `pika.gen.ts` at the project root is already picked up. No extra step needed.
-2. **Explicit inclusion** — If your `include` is scoped to a subdirectory only (e.g. `"include": ["src"]`, common in Vite + React/Vue templates), `pika.gen.ts` at the root is **not** covered. Add it explicitly:
+or:
 
 ```jsonc
-// tsconfig.json (or tsconfig.app.json)
 {
   "include": ["src", "pika.gen.ts"]
 }
 ```
 
-**Always verify** that the project's `tsconfig` `include` pattern covers `pika.gen.ts`. When guiding a full setup, mention this step — especially for scaffolded templates where `include` defaults to `["src"]`.
+A standalone `tsc --noEmit` run also needs the generated file to exist. Run a build/codegen step first or commit `pika.gen.ts` when CI typechecks before building.
 
 ## Engine Configuration
 
-Create a config file at the project root. Supported file names:
+Supported root config names, in discovery priority order:
 
-- `pika.config.{ts,js,mjs,cjs,mts,cts}`
-- `pikacss.config.{ts,js,mjs,cjs,mts,cts}`
+- `pika.config.{ts,mts,cts,js,mjs,cjs}`
+- `pikacss.config.{ts,mts,cts,js,mjs,cjs}`
+
+Use one config file only.
 
 ```ts
 // pika.config.ts
 import { defineEngineConfig } from '@pikacss/core'
+import { icons } from '@pikacss/plugin-icons/node'
 import { reset } from '@pikacss/plugin-reset'
-import { icons } from '@pikacss/plugin-icons'
 
 export default defineEngineConfig({
   prefix: 'pk-',
@@ -147,128 +172,136 @@ export default defineEngineConfig({
 })
 ```
 
-### Core Config Options
+The Node icons adapter is the normal choice in bundler config when locally installed `@iconify-json/*` packages or `autoInstall` are required. The neutral `@pikacss/plugin-icons` entry only handles custom collections and CDN loading unless custom runtime capabilities are supplied.
+
+### Core config options
 
 | Option | Type | Default | Purpose |
 |---|---|---|---|
-| `plugins` | `EnginePlugin[]` | `[]` | Array of engine plugins |
-| `prefix` | `string` | `'pk-'` | Atomic class name prefix (e.g. `pk-a1b2`) |
-| `defaultSelector` | `string` | `'.%'` | Default CSS selector template (`%` = class placeholder) |
-| `preflights` | `Preflight[]` | `[]` | Global CSS rules emitted before utilities |
+| `plugins` | `EnginePlugin[]` | `[]` | Engine plugins |
+| `prefix` | `string` | `'pk-'` | Atomic class prefix |
+| `defaultSelector` | `string` | `'.%'` | Atomic selector template; `%` is the generated class placeholder |
+| `preflights` | `Preflight[]` | `[]` | Global CSS emitted before utilities |
 | `cssImports` | `string[]` | `[]` | CSS `@import` statements prepended to output |
-| `layers` | `Record<string, number>` | `{ preflights: 1, utilities: 10 }` | CSS `@layer` ordering |
-| `defaultPreflightsLayer` | `string` | `'preflights'` | Layer name for preflight CSS |
-| `defaultUtilitiesLayer` | `string` | `'utilities'` | Layer name for atomic utilities |
-| `autocomplete` | `AutocompleteConfig` | `{}` | IDE autocomplete configuration |
+| `layers` | `Record<string, number>` | `{ preflights: 1, utilities: 10 }` | CSS layer ordering |
+| `defaultPreflightsLayer` | `string` | `'preflights'` | Default preflight layer |
+| `defaultUtilitiesLayer` | `string` | `'utilities'` | Default atomic utility layer |
+| `autocomplete` | `AutocompleteConfig` | `{}` | Generated IDE/type autocomplete configuration |
 
-### Plugin-Augmented Config Options
+### Plugin-augmented config keys
 
-These options are added to `EngineConfig` via TypeScript module augmentation by built-in internal plugins. Available in every project — no extra imports needed:
+Core internal plugins add `important`, `selectors`, `shortcuts`, `variables`, and `keyframes`. Official packages additionally augment keys such as `reset`, `icons`, `fonts`, and `designTokens` when their modules are imported.
 
-| Option | Type | Purpose |
-|---|---|---|
-| `important` | `ImportantConfig` | Add `!important` to all utilities |
-| `selectors` | `SelectorsConfig` | Named selector aliases (pseudo-classes, media queries) |
-| `shortcuts` | `ShortcutsConfig` | Named style shortcuts reusable in `pika()` calls |
-| `variables` | `VariablesConfig` | CSS custom properties registered under `definitions`, with scoping, autocomplete control, and pruning |
-| `keyframes` | `KeyframesConfig` | Named `@keyframes` definitions with pruning |
+Read `references/customizations.md` for exact shapes. Do not invent removed `define*` wrapper helpers for reusable config fragments.
 
-For detailed usage of these options (variables with dark mode, keyframes, preflights, selectors config, shortcuts with nested selectors, `__layer`/`__important` per-style control), see `references/customizations.md`.
+## Usage
 
-**Dark mode / theming note**: When configuring `variables.definitions` with scoped selectors and `selectors` aliases for dark mode, the scoped key and alias CSS template must match **the project's actual dark mode mechanism** (class-based `html.dark`, data-attribute `[data-theme="dark"]`, or media query). Read the reference for examples of each approach.
+### Style items
 
-### cssImports vs preflights
+`pika()` accepts one or more style items:
 
-- `cssImports` — static `@import` strings placed first in the CSS output. Use for external stylesheets (Google Fonts CDN, normalize.css CDN, etc.).
-- `preflights` — CSS rules rendered after imports but before utilities, scoped to `@layer`. Use for reset styles, global variables, and custom base rules.
-
-## Usage — pika() Macro
-
-`pika()` accepts one or more **style items** and is replaced at build time with the generated class names.
-
-### Style Items
-
-A style item is one of:
-- A **StyleDefinition object** — CSS properties as key-value pairs
-- A **shortcut name** — a string referencing a named shortcut from config or plugins
+- A style definition object.
+- A registered shortcut name.
+- An unresolved string, which is preserved as an existing/raw class name.
 
 ```ts
-// StyleDefinition object — both camelCase and kebab-case property names work
-const cls = pika({
-  display: 'flex',
-  alignItems: 'center',        // camelCase
-  'font-size': '1rem',         // kebab-case
-})
-
-// Named shortcut
-const cls2 = pika('my-shortcut')
-
-// Multiple items — mix objects and shortcuts
-const cls3 = pika({ display: 'flex' }, 'my-shortcut', { color: 'red' })
+const classes = pika(
+  'existing-class',
+  'flex-center',
+  {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '1rem',
+  },
+)
 ```
 
-CSS property values can use tuple syntax for fallbacks: `color: ['red', 'var(--fallback)']` emits multiple declarations. Custom properties are also supported: `'--my-var': '16px'`.
+Both camelCase and kebab-case CSS properties are accepted.
 
-### pika() Variants
+### CSS value fallbacks
 
-| Syntax | Output type | Purpose |
+Use `[primaryValue, fallbackValues[]]`. Fallback declarations are emitted first, then the primary value:
+
+```ts
+pika({
+  color: ['oklch(0.7 0.15 220)', ['rgb(0 120 255)', 'blue']],
+})
+```
+
+Do not use a flat array such as `['red', 'blue']`; that is not the fallback tuple shape.
+
+### Function variants
+
+| Syntax | Output | Purpose |
 |---|---|---|
-| `pika(...)` | `string` (default) | Space-separated class names |
-| `pika.str(...)` | `string` | Force space-separated string |
-| `pika.arr(...)` | `string[]` | Force array of class names |
-| `pikap(...)` | same as `pika()` | Preview mode — renders CSS in IDE tooltip |
-| `pikap.str(...)` | `string` | Preview + force string |
-| `pikap.arr(...)` | `string[]` | Preview + force array |
+| `pika(...)` | Configured default | Uses `transformedFormat` |
+| `pika.str(...)` | `string` | Forces a space-separated class string |
+| `pika.arr(...)` | `string[]` | Forces an array of class names |
+| `pikap(...)` | Configured default | Adds generated CSS to TypeScript hover information |
+| `pikap.str(...)` | `string` | Preview plus forced string |
+| `pikap.arr(...)` | `string[]` | Preview plus forced array |
 
-The default output format is `string` (configurable via the build plugin's `transformedFormat` option — see `references/build-options.md`).
+`pikap` preview requires TypeScript codegen and a visible generated declaration file.
 
-### Nested Selectors
+### Nested selectors
 
-Style properties can be nested under selector keys to apply styles conditionally:
+Built-in pseudo selectors use a `$` prefix; CSS at-rules are written directly. Named aliases must be registered under `selectors.definitions`.
 
 ```ts
 pika({
   color: 'red',
-  ':hover': { opacity: '0.8' },
-  '@dark': { color: 'white' },
-  '@screen-md': { fontSize: '1.2rem' },
+  '$:hover': { opacity: '0.8' },
+  '$::before': { content: '""' },
+  '@media (min-width: 768px)': { fontSize: '1.2rem' },
+  '@dark': { color: 'white' }, // custom alias; register it first
 })
 ```
 
-Selector keys must be registered in the config's `selectors` option. The `$` character in the CSS selector template represents the atomic class. See `references/customizations.md` for the full selectors config format.
+```ts
+selectors: {
+  definitions: [
+    ['@dark', 'html.dark $'],
+  ],
+}
+```
 
-### Per-Style Control: __layer and __important
+Inside a selector definition, `$` is replaced by the generated atomic class selector.
 
-Individual style definitions can override layer placement or add `!important`:
+### Per-definition controls
 
 ```ts
 pika({
-  __layer: 'components',        // Place these utilities in a custom layer
-  __important: true,            // Add !important to all properties in this item
-  display: 'flex',
-  color: 'red',
+  __shortcut: ['flex-center', 'card'],
+  __layer: 'components',
+  __important: true,
+  gap: '1rem',
 })
 ```
+
+- `__shortcut` expands shortcuts before the object's own declarations, so explicit declarations win.
+- `__layer` selects a configured layer.
+- `__important` applies `!important`, including to expanded shortcut declarations.
 
 ## Official Plugins
 
-| Plugin | Package | Purpose | Reference |
+| Plugin | Package | Important adapter rule | Reference |
 |---|---|---|---|
-| Reset | `@pikacss/plugin-reset` | CSS reset/normalize as preflight | `references/plugin-reset.md` |
-| Icons | `@pikacss/plugin-icons` | `i-{collection}:{name}` icon shortcuts via Iconify | `references/plugin-icons.md` |
-| Fonts | `@pikacss/plugin-fonts` | Web font loading and `font-{token}` shortcuts | `references/plugin-fonts.md` |
-| Typography | `@pikacss/plugin-typography` | `prose-*` shortcuts and `--pk-prose-*` variables | `references/plugin-typography.md` |
+| Reset | `@pikacss/plugin-reset` | No runtime split | `references/plugin-reset.md` |
+| Icons | `@pikacss/plugin-icons` | Use `/node` for local Iconify packages and `autoInstall`; neutral entry supports custom/CDN sources | `references/plugin-icons.md` |
+| Fonts | `@pikacss/plugin-fonts` | No runtime split | `references/plugin-fonts.md` |
+| Typography | `@pikacss/plugin-typography` | No runtime split | `references/plugin-typography.md` |
+| Design Tokens | `@pikacss/plugin-design-tokens` | Use `/node` for JSON/Markdown file paths; neutral entry supports inline tokens | `references/plugin-design-tokens.md` |
 
-Each plugin is a function imported from its package and added to the `plugins` array in `pika.config.ts`. Load the corresponding reference file for configuration options, examples, and troubleshooting.
+Each plugin factory belongs in `plugins`. Its module import also activates the corresponding `EngineConfig` augmentation.
 
-## Define Helpers
+## Public Define Helpers
 
-`@pikacss/core` now keeps only two public define helpers:
+`@pikacss/core` exposes two public define helpers:
 
-- `defineEngineConfig(config)` — type-safe engine config
-- `defineEnginePlugin(plugin)` — type-safe plugin definition
+- `defineEngineConfig(config)`
+- `defineEnginePlugin(plugin)`
 
-For reusable style objects, preflights, keyframes, selectors, shortcuts, or variable maps, use plain object literals with `satisfies` or explicit type annotations instead of helper wrappers.
+For reusable styles, preflights, selectors, shortcuts, variables, or keyframes, use plain object literals with `satisfies` or explicit type annotations.
 
 ## ESLint
 
@@ -279,52 +312,54 @@ import pikacss from '@pikacss/eslint-config'
 export default [pikacss()]
 ```
 
-The default export is a function that returns a flat-config entry. The `fnName` option (default: `'pika'`) lets you customize the function name if needed: `pikacss({ fnName: 'pika' })`.
+The default export returns a flat-config entry. Keep its `fnName` aligned with the build plugin when using a custom compile-time function name.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Config not detected | File name or location wrong | Use `pika.config.ts` (or `pikacss.config.ts`) at the project root |
-| Styles not applied | Missing CSS import | Add `import 'pika.css'` to your entry file (not needed for Nuxt) |
-| Type errors on `pika()` | Missing generated types | Ensure `pika.gen.ts` is included in your tsconfig |
-| `pika is not defined` in Vue/Svelte/Solid | Vite plugin not running or an older unplugin build | Current Vite integration uses `enforce: 'pre'`, so `[vue(), pikacss()]` is supported. If this still appears, verify the plugin is enabled and update to a version that includes that behavior |
-| Plugin config types missing | Module augmentation not loaded | Import the plugin in `pika.config.ts` — TypeScript picks up the augmented types |
-| Build errors with dynamic args | Non-static pika() arguments | All `pika()` arguments must be statically analyzable — no runtime variables |
-| Plugin order issues | Engine plugins applied in wrong order | Reorder the `plugins` array in `pika.config.ts` — PikaCSS engine plugins are applied in order |
-| Plugin hook not firing | Plugin misconfigured | Check: (1) plugin is in `plugins` array, (2) factory function is **called** — `myPlugin()` not `myPlugin`, (3) hook name is spelled correctly (e.g. `configureEngine` not `configEngine`) |
-| Icons not rendering | Collection package missing | Install `@iconify-json/{collection}` or enable `autoInstall` — see `references/plugin-icons.md` |
-| Wrong icon appearance | Mask vs background mode mismatch | Read the icon modes section in `references/plugin-icons.md` |
+| Config not detected | Wrong name, duplicate configs, or wrong directory | Keep one supported config file at the project root |
+| Styles not applied | Missing virtual CSS import | Add `import 'pika.css'` outside Nuxt |
+| `Cannot find name 'pika'` | Generated declarations absent from the TS program | Generate `pika.gen.ts` and include it, or write it under `src` |
+| `pika is not defined` survives into output | Build adapter is missing, disabled, or not scanning the file | Verify the correct bundler adapter and supported extension; update old integrations |
+| Vue transform ordering issue | Old Vite integration | Current Vite adapter uses `enforce: 'pre'`; update before changing plugin order |
+| Dynamic argument build error | Argument cannot be statically evaluated | Replace runtime values with CSS variables, variant maps, or shortcuts |
+| Local icon collection is ignored | Neutral icons entry used | Import `icons` from `@pikacss/plugin-icons/node` |
+| Design-token file source is ignored | Neutral design-tokens entry used | Import `designTokens` from `@pikacss/plugin-design-tokens/node` |
+| Plugin config types missing | Augmenting package was never imported | Import and call the plugin factory in `pika.config.*` |
+| Plugin hook not firing | Factory not called or wrong hook name | Use `plugins: [myPlugin()]` and exact lifecycle hook names |
+| External plugin data does not trigger reload | Dependency path not registered | Call `engine.addConfigDependency(path)` in `configureEngine` |
 
-## Plugin Development (Quick Start)
+## Plugin Development Quick Start
 
-For full details, load `references/plugin-development.md`. The essentials:
+Read `references/plugin-development.md` before implementing a plugin. Current essentials:
 
-- Plugins are plain objects created with `defineEnginePlugin({ name, order?, ...hooks })`.
-- Hooks are direct methods — no `setup()` wrapper.
-- Order tiers: `'pre'` → default (`undefined`) → `'post'`.
-- Use `configureRawConfig` for injecting config defaults, `configureEngine` for registering preflights/selectors/shortcuts/keyframes/variables.
-- Use TypeScript module augmentation on `EngineConfig` to expose plugin options to users.
-- Test with `createEngine` + `defineEngineConfig` from `@pikacss/core`.
+- Hooks are direct methods on `defineEnginePlugin({ ... })`; there is no `setup()` wrapper.
+- Order is `'pre'` → default → `'post'`.
+- Every hook receives an optional `EnginePluginContext`; use `context.onDiagnostic` for structured warnings/errors.
+- Use `configureRawConfig` for defaults and raw config composition.
+- Use `configureEngine` for runtime registration, diagnostics through `engine.reportDiagnostic`, and external file dependencies through `engine.addConfigDependency`.
+- Extend `EngineConfig` with TypeScript module augmentation.
+- Test with `createEngine(config, { onDiagnostic })` and assert diagnostics as data rather than spying on `console`.
 
 ## Workflow
 
-### Consumer Setup
+### Consumer setup
 
-1. Identify the user's project setup (Vite, Nuxt, Webpack, Rollup, esbuild, Rspack, Rolldown).
-2. Install `@pikacss/unplugin-pikacss` (or `@pikacss/nuxt-pikacss` for Nuxt) and any desired plugins.
-3. Set up the build plugin in the bundler config.
-4. Create `pika.config.ts` with `defineEngineConfig()`.
-5. Add `import 'pika.css'` to the entry file (skip for Nuxt).
-6. Demonstrate `pika()` usage with the user's framework.
-7. Configure selectors, shortcuts, variables, and keyframes as needed — load `references/customizations.md` for detailed patterns.
-8. Add ESLint config if desired.
+1. Confirm Node.js and bundler versions.
+2. Install `@pikacss/core` plus the correct integration package.
+3. Register the bundler plugin or Nuxt module.
+4. Create one root config file.
+5. Import `pika.css` outside Nuxt.
+6. Ensure `pika.gen.ts` exists and is included by TypeScript.
+7. Use only supported source extensions and statically analyzable arguments.
+8. Load the relevant customization or official-plugin reference before proposing advanced config.
 
-### Plugin Authoring
+### Plugin authoring
 
-1. Understand the user's plugin goal (what CSS behavior to add).
-2. Load `references/plugin-development.md` for hooks, engine API, and patterns.
-3. Reference official plugins (reset, icons, fonts, typography) as real-world examples.
-4. Choose hooks based on needs; use module augmentation for user configuration.
-5. Register layers for CSS ordering if injecting preflight CSS.
-6. Write tests using `createEngine` from `@pikacss/core`.
+1. Define the user-facing behavior and config augmentation.
+2. Choose the smallest lifecycle hooks that implement it.
+3. Keep platform-specific capabilities behind explicit adapters, such as `/node` entries.
+4. Emit structured diagnostics instead of assuming a console.
+5. Register every external file through `engine.addConfigDependency`.
+6. Add `createEngine` tests for normal behavior, diagnostics, and hook ordering.

--- a/skills/pikacss-use/SKILL.md
+++ b/skills/pikacss-use/SKILL.md
@@ -158,7 +158,7 @@ Supported root config names, in discovery priority order:
 - `pika.config.{ts,mts,cts,js,mjs,cjs}`
 - `pikacss.config.{ts,mts,cts,js,mjs,cjs}`
 
-Use one config file only.
+Use at most one config file. A config file is optional when the default engine behavior is sufficient.
 
 ```ts
 // pika.config.ts
@@ -349,7 +349,7 @@ Read `references/plugin-development.md` before implementing a plugin. Current es
 1. Confirm Node.js and bundler versions.
 2. Install `@pikacss/core` plus the correct integration package.
 3. Register the bundler plugin or Nuxt module.
-4. Create one root config file.
+4. Add at most one root config file when customization is needed; zero-config defaults are supported.
 5. Import `pika.css` outside Nuxt.
 6. Ensure `pika.gen.ts` exists and is included by TypeScript.
 7. Use only supported source extensions and statically analyzable arguments.

--- a/skills/pikacss-use/references/build-options.md
+++ b/skills/pikacss-use/references/build-options.md
@@ -147,7 +147,8 @@ A plugin that reads an external file must register that path, including a missin
 `@pikacss/nuxt-pikacss`:
 
 - Registers the Vite adapter internally.
-- Applies Nuxt-aware default scan exclusions.
+- Uses the unplugin's default JS-family and Vue scan patterns, including `.nuxt` and `.output` exclusions.
+- Resolves config discovery and generated paths from Nuxt's project root instead of Vite's `srcDir` root.
 - Generates a Nuxt plugin/template that imports `pika.css`.
 - Sets its own integration package identity for generated output.
 

--- a/skills/pikacss-use/references/build-options.md
+++ b/skills/pikacss-use/references/build-options.md
@@ -126,7 +126,7 @@ Config discovery only checks the project root and uses this priority:
 1. `pika.config.{ts,mts,cts,js,mjs,cjs}`
 2. `pikacss.config.{ts,mts,cts,js,mjs,cjs}`
 
-When multiple candidates exist, the first is used and the others are ignored with a diagnostic. Recommend keeping one config file.
+When multiple candidates exist, the first is used and the others are logged as ignored with a warning. Recommend keeping at most one config file.
 
 - Production builds throw on invalid config or engine initialization.
 - Development retains the last successfully initialized engine after a transient config error so the server can continue running.

--- a/skills/pikacss-use/references/build-options.md
+++ b/skills/pikacss-use/references/build-options.md
@@ -1,25 +1,36 @@
 # Build Plugin Options
 
-> Read this when the user asks about customizing the build plugin behavior — scan patterns, output format, generated file paths, or function name.
+> Read this when the user asks about build-tool setup, scan patterns, project roots, output formats, generated paths, custom function names, wrapper integrations, HMR, or config reload behavior.
 
-If the project is Nuxt, prefer `@pikacss/nuxt-pikacss` instead of manually wiring `@pikacss/unplugin-pikacss/vite`. The Nuxt module configures the Vite plugin for you and injects a generated Nuxt plugin/template that imports `pika.css`, so manual CSS imports are not needed there.
+## Compatibility
 
-## Unplugin Options
+- PikaCSS packages require Node.js 22 or later.
+- The Vite adapter supports Vite 7 and 8 (`^7.0.0 || ^8.0.0`).
+- Supported unplugin exports: Vite, Rollup, Webpack, esbuild, Rspack, and Rolldown.
+- Nuxt projects should use `@pikacss/nuxt-pikacss`; do not also register the Vite adapter manually.
 
-The `pikacss()` factory function from each bundler subpath export accepts an options object:
+## Basic Configuration
 
 ```ts
 import pikacss from '@pikacss/unplugin-pikacss/vite'
+import { defineConfig } from 'vite'
 
 export default defineConfig({
   plugins: [
     pikacss({
-      // All options below are optional — defaults work for most projects
+      // Defaults are sufficient for most projects.
       fnName: 'pika',
       transformedFormat: 'string',
       scan: {
         include: ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}'],
-        exclude: ['node_modules/**', 'dist/**', '.git/**', '.nuxt/**', '.output/**', 'coverage/**'],
+        exclude: [
+          'node_modules/**',
+          'dist/**',
+          '.git/**',
+          '.nuxt/**',
+          '.output/**',
+          'coverage/**',
+        ],
       },
     }),
   ],
@@ -28,70 +39,116 @@ export default defineConfig({
 
 ## Option Reference
 
-The default generated filenames (`pika.gen.ts` and `pika.gen.css`) are convenience defaults, not required names. When you pass a string to `tsCodegen` or `cssCodegen`, that exact custom path is used.
-
 | Option | Type | Default | Purpose |
 |---|---|---|---|
-| `fnName` | `string` | `'pika'` | Base function name recognized by the transform |
-| `transformedFormat` | `'string' \| 'array'` | `'string'` | Output format of `pika()` calls |
-| `scan.include` | `string[]` | `['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}']` | Glob patterns for files to scan |
-| `scan.exclude` | `string[]` | `['node_modules/**', 'dist/**', '.git/**', '.nuxt/**', '.output/**', 'coverage/**']` | Glob patterns to exclude |
-| `config` | `EngineConfig \| string` | auto-discovery | Engine config object or path to config file |
-| `autoCreateConfig` | `boolean` | `false` | Opt in to scaffolding a default config file when none is found |
-| `tsCodegen` | `boolean \| string` | `true` (`pika.gen.ts`) | TypeScript declaration output path when set to a string; `false` disables codegen |
-| `cssCodegen` | `true \| string` | `true` (`pika.gen.css`) | CSS output file path when set to a string; cannot be disabled |
+| `cwd` | `string` | Bundler root, then `process.cwd()` | Working directory for config discovery, scan globs, and codegen paths |
+| `scan.include` | `string \| string[]` | `**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue}` | Source globs to scan |
+| `scan.exclude` | `string \| string[]` | Dependencies, output, VCS, Nuxt, and coverage globs | Source globs to exclude |
+| `config` | `EngineConfig \| string` | Auto-discovery | Inline engine config or path to a config file |
+| `autoCreateConfig` | `boolean` | `false` | Opt in to scaffolding `pika.config.js` when no config exists |
+| `fnName` | `string` | `'pika'` | Base compile-time function name; preview and `.str`/`.arr` variants derive from it |
+| `transformedFormat` | `'string' \| 'array'` | `'string'` | Default output format for the base function |
+| `tsCodegen` | `boolean \| string` | `true` → `pika.gen.ts` | Redirect or disable TypeScript declaration generation |
+| `cssCodegen` | `true \| string` | `true` → `pika.gen.css` | CSS output path; CSS codegen cannot be disabled |
+| `currentPackageName` | `string` | `'@pikacss/unplugin-pikacss'` | Package identity embedded in generated declarations/config scaffolds; wrapper integrations only |
 
-## Common Scenarios
+### Important override semantics
 
-### Change output format to array
+Explicit `scan.include` and `scan.exclude` values **replace** their corresponding defaults. They are not merged. If a user supplies a custom exclusion list, remind them to retain every exclusion they still need.
+
+`cwd` resolution priority is:
+
+1. Explicit `cwd` option.
+2. Bundler root/context where an adapter exposes one.
+3. `process.cwd()`.
+
+Use `currentPackageName` only when publishing a wrapper integration. It must name the package users actually import; normal applications should leave it untouched.
+
+## Supported Source Files
+
+The built-in AST processors support:
+
+- `js`, `mjs`, `cjs`, `jsx`
+- `ts`, `mts`, `cts`, `tsx`
+- Vue SFCs (`vue`)
+
+Svelte, Astro, and plain HTML are not processed. Narrowing scan globs to an unsupported extension does not add compiler support.
+
+```ts
+pikacss({
+  scan: {
+    include: ['src/**/*.{ts,tsx,vue}', 'shared/**/*.mts'],
+  },
+})
+```
+
+## Generated Files
+
+The default generated paths are convenience defaults rather than required names:
+
+```ts
+pikacss({
+  tsCodegen: './src/generated/pika.gen.ts',
+  cssCodegen: './src/generated/pika.gen.css',
+})
+```
+
+- `import 'pika.css'` remains the public virtual CSS import even when `cssCodegen` changes.
+- `tsCodegen: false` disables declaration generation and therefore removes generated global types and `pikap` hover output.
+- `cssCodegen` accepts only `true` or a string path.
+- `autoCreateConfig` is intentionally opt-in because silent repository writes are unsafe in CI, containers, and read-only workspaces.
+
+## Output Format
 
 ```ts
 pikacss({ transformedFormat: 'array' })
-// pika({ display: 'flex' }) → ['pk-a1b2'] instead of 'pk-a1b2'
+// pika({ display: 'flex' }) → ['pk-a1b2']
 ```
 
-### Custom output paths
+Call-site variants override the default:
 
-These filenames are examples only. Any custom path that fits the project layout is valid; the important part is setting `tsCodegen` and `cssCodegen` to the paths you want generated.
+- `.str()` always produces a string.
+- `.arr()` always produces an array.
+- Preview variants follow the same rule.
 
-```ts
-pikacss({
-  tsCodegen: 'src/generated/pika.d.ts',
-  cssCodegen: 'src/generated/pika.css',
-})
-```
-
-### Customize the scan globs
-
-JS-family sources (`js`, `mjs`, `cjs`, `jsx`, `ts`, `mts`, `cts`, `tsx`) and Vue SFCs (`vue`) are supported by the AST-based transform. The default `scan.include` already covers every supported extension; override it to narrow the scan to specific directories:
-
-```ts
-pikacss({
-  scan: { include: ['src/**/*.{ts,tsx,vue}', 'shared/**/*.mts'] },
-})
-```
-
-Setting `scan.include` explicitly replaces the default glob entirely. Other markup formats (Svelte, Astro, plain HTML) are not processed.
-
-### Disable TypeScript generation
-
-```ts
-pikacss({ tsCodegen: false })
-```
-
-### Custom function name
+## Custom Function Name
 
 ```ts
 pikacss({ fnName: 'css' })
-// Now use css({ display: 'flex' }) instead of pika(...)
 ```
 
-## HMR / Dev Server
+The generated globals become `css`, `css.str`, `css.arr`, `cssp`, `cssp.str`, and `cssp.arr`. Keep `@pikacss/eslint-config`'s `fnName` aligned with this value.
 
-The plugin automatically handles:
-- Hot module replacement for CSS changes during development
-- Config file watching — changes to `pika.config.ts` trigger full engine reinit
-- Source file watching — `pika()` call changes trigger targeted transforms
-- Debounced codegen writes (300ms) to prevent thrashing
+## Config Loading and Error Behavior
 
-No consumer configuration is needed for HMR.
+Config discovery only checks the project root and uses this priority:
+
+1. `pika.config.{ts,mts,cts,js,mjs,cjs}`
+2. `pikacss.config.{ts,mts,cts,js,mjs,cjs}`
+
+When multiple candidates exist, the first is used and the others are ignored with a diagnostic. Recommend keeping one config file.
+
+- Production builds throw on invalid config or engine initialization.
+- Development retains the last successfully initialized engine after a transient config error so the server can continue running.
+
+## HMR and Watching
+
+The integrations automatically handle:
+
+- CSS updates after transformed source changes.
+- Config file reloads.
+- External config dependencies registered by plugins through `engine.addConfigDependency(path)`.
+- Debounced generated-file writes.
+
+A plugin that reads an external file must register that path, including a missing path that should trigger reload when later created. Without registration, changing the external file does not recreate the engine.
+
+## Nuxt-Specific Behavior
+
+`@pikacss/nuxt-pikacss`:
+
+- Registers the Vite adapter internally.
+- Applies Nuxt-aware default scan exclusions.
+- Generates a Nuxt plugin/template that imports `pika.css`.
+- Sets its own integration package identity for generated output.
+
+Do not recommend a manual `import 'pika.css'` or a duplicate Vite plugin in Nuxt projects.

--- a/skills/pikacss-use/references/customizations.md
+++ b/skills/pikacss-use/references/customizations.md
@@ -1,26 +1,10 @@
 # Customizations
 
-> Read this when the user asks about variables (including dark mode/theming), keyframes, preflights, per-style layer control, per-style !important, selectors, or shortcuts in detail.
-
-## Table of Contents
-
-1. [Variables and Theming](#variables-and-theming)
-2. [Keyframes](#keyframes)
-3. [Preflights](#preflights)
-4. [Selectors](#selectors)
-5. [Shortcuts](#shortcuts)
-6. [Per-Style Layer Control (__layer)](#per-style-layer-control)
-7. [Per-Style !important (__important)](#per-style-important)
-8. [CSS Property Syntax](#css-property-syntax)
-9. [Typed Config Fragments](#typed-config-fragments)
-
----
+> Read this when the user asks about variables and themes, keyframes, preflights, selectors, shortcuts, `__shortcut`, layers, `!important`, CSS property syntax, value fallbacks, or typed reusable config fragments.
 
 ## Variables and Theming
 
-Register variables under `variables.definitions`. Plain values default to `var(--token)` suggestions for all CSS properties. Use the object form when you need manual autocomplete control or want to disable suggestions with `autocomplete.asValueOf: '-'`.
-
-### Basic Variables
+Register variables under `variables.definitions`:
 
 ```ts
 export default defineEngineConfig({
@@ -34,132 +18,112 @@ export default defineEngineConfig({
 })
 ```
 
-### Dark Mode with Scoped Selectors
-
-Variables can be scoped to CSS selectors for theme switching:
-
-```ts
-export default defineEngineConfig({
-  variables: {
-    definitions: {
-      // Default (light) — applied to :root
-      '--color-bg': '#ffffff',
-      '--color-text': '#1a1a1a',
-
-      // Dark mode — scoped to html.dark selector
-      'html.dark': {
-        '--color-bg': '#1a1a1a',
-        '--color-text': '#f5f5f5',
-      },
-    },
-  },
-})
-```
-
-Use in pika():
-
-```ts
-pika({ color: 'var(--color-text)', 'background-color': 'var(--color-bg)' })
-```
-
-Toggle dark mode at runtime: `document.documentElement.classList.toggle('dark')`
-
-### Data-Attribute Scoping
-
-If dark mode is toggled via a `data-theme` attribute (e.g. `<html data-theme="dark">`), use the attribute selector as the scoped key:
+Plain values use the default autocomplete and pruning policy. Use object values for per-variable control:
 
 ```ts
 variables: {
   definitions: {
-    '--color-bg': '#ffffff',
-    '--color-text': '#1a1a1a',
-
-    '[data-theme="dark"]': {
-      '--color-bg': '#1a1a1a',
-      '--color-text': '#f5f5f5',
+    '--color-primary': {
+      value: '#3b82f6',
+      autocomplete: {
+        asValueOf: ['color', 'background-color'],
+        asProperty: true,
+      },
+      pruneUnused: false,
     },
   },
 }
 ```
 
-Toggle: `document.documentElement.setAttribute('data-theme', 'dark')`
+- `autocomplete.asValueOf: '*'` suggests the variable for every CSS property.
+- `autocomplete.asValueOf: '-'` suppresses value suggestions.
+- `autocomplete.asProperty` controls whether the variable name itself is suggested as a custom property.
 
-### Media Query Scoping
+### Scoped themes
+
+Non-variable keys are emitted as selector scopes:
 
 ```ts
 variables: {
   definitions: {
     '--color-bg': '#fff',
-    '@media (prefers-color-scheme: dark)': {
+    '--color-text': '#1a1a1a',
+
+    'html.dark': {
       '--color-bg': '#1a1a1a',
+      '--color-text': '#f5f5f5',
+    },
+
+    '[data-theme="high-contrast"]': {
+      '--color-text': '#000',
+    },
+
+    '@media (prefers-color-scheme: dark)': {
+      '--system-bg': '#1a1a1a',
     },
   },
 }
 ```
 
+The scope must match the application's actual theme switch. Do not combine a class-based variable scope with a data-attribute selector alias unless the application applies both.
+
 ### Pruning
 
-- **`pruneUnused: true`** (default) — variables not referenced by any atomic style or preflight are stripped from output.
-- **`safeList`** — variable names that should always be emitted:
+Unused variables are pruned by default. Keep variables through either:
 
 ```ts
 variables: {
-  definitions: {
-    '--color-accent': '#f00',
-    '--shadow-elevated': '0 12px 40px rgb(0 0 0 / 0.12)',
-  },
   pruneUnused: true,
   safeList: ['--color-accent'],
+  definitions: {
+    '--color-accent': '#f00',
+    '--always-keep': {
+      value: '1rem',
+      pruneUnused: false,
+    },
+  },
 }
 ```
 
----
+Variable dependencies are expanded transitively. If an emitted variable references another variable, the dependency is emitted too.
 
 ## Keyframes
 
-### Tuple Format
+Definitions may use tuple or object form:
 
 ```ts
 export default defineEngineConfig({
   keyframes: {
     definitions: [
-      ['spin', { from: { transform: 'rotate(0deg)' }, to: { transform: 'rotate(360deg)' } }],
-      ['fade-in', { '0%': { opacity: '0' }, '100%': { opacity: '1' } }],
+      ['spin', {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      }],
+      {
+        name: 'fade-in',
+        frames: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+      },
     ],
   },
 })
 ```
 
-### Object Format
-
-```ts
-keyframes: {
-  definitions: [
-    { name: 'spin', frames: { from: { transform: 'rotate(0deg)' }, to: { transform: 'rotate(360deg)' } } },
-  ],
-}
-```
-
-### Usage
-
-Reference in pika() via the `animation` or `animation-name` property:
+Reference names through `animation` or `animationName`:
 
 ```ts
 pika({ animation: 'spin 1s linear infinite' })
 ```
 
-### Pruning
-
-- **`pruneUnused: true`** (default) — keyframes not referenced by any `animation` or `animation-name` style are stripped.
-- Set `pruneUnused: false` on individual definitions to keep them regardless.
-
----
+Unused keyframes are pruned by default. Use the definition's pruning controls when a keyframe must always remain.
 
 ## Preflights
 
-Preflights accept multiple formats:
+Preflights accept multiple public shapes.
 
-### Raw CSS String
+### Raw CSS
 
 ```ts
 preflights: [
@@ -167,163 +131,268 @@ preflights: [
 ]
 ```
 
-### Definition Object
+### Definition object
 
 ```ts
 preflights: [
   {
-    body: { margin: '0', 'font-family': 'system-ui, sans-serif' },
-    '*, *::before, *::after': { 'box-sizing': 'border-box' },
+    body: {
+      margin: '0',
+      fontFamily: 'system-ui, sans-serif',
+    },
+    '*, *::before, *::after': {
+      boxSizing: 'border-box',
+    },
   },
 ]
 ```
 
-### Function (dynamic)
+### Function
 
 ```ts
 preflights: [
-  (engine, isFormatted) => `
-    :root { --prefix: ${engine.config.prefix}; }
+  (engine, isFormatted, context) => `
+    :root { --class-prefix: ${engine.config.prefix}; }
   `,
 ]
 ```
 
-### With Layer and ID
+When one preflight invokes another during rendering, forward the render-pass context to `engine.invokePreflight(fn, isFormatted, context)` so each function executes once per pass.
+
+### Wrapped with metadata
 
 ```ts
 preflights: [
-  { layer: 'base', id: 'my-reset', preflight: '*, *::before { box-sizing: border-box; }' },
+  {
+    id: 'app-base',
+    layer: 'base',
+    preflight: 'html { color-scheme: light dark; }',
+  },
 ]
 ```
 
----
+Stable IDs are useful when plugins need to recognize or exclude their own preflight.
 
 ## Selectors
 
-Register named selector aliases used in pika() style nesting:
+There are three distinct selector forms. Do not mix their syntax.
 
-The selector alias and its CSS template must match **the user's chosen dark mode mechanism**:
+### Built-in pseudo selectors
 
-- Class-based (`html.dark`): `['@dark', 'html.dark $']`
-- Data-attribute (`[data-theme="dark"]`): `['@dark', '[data-theme="dark"] $']`
-- Media query: `['@dark', '@media (prefers-color-scheme: dark)']`
-
-```ts
-selectors: {
-  definitions: [
-    // [alias, actual CSS selector]
-    [':hover', '$:hover'],
-    [':focus', '$:focus'],
-    ['::before', '$::before'],
-    ['@dark', 'html.dark $'],           // ← class-based example
-    ['@light', 'html:not(.dark) $'],
-    ['@sm', '@media screen and (min-width: 640px)'],
-    ['@md', '@media screen and (min-width: 768px)'],
-    ['@lg', '@media screen and (min-width: 1024px)'],
-  ],
-}
-```
-
-- `$` — placeholder for the atomic class name
-- Media queries don't need `$` — they wrap the rule block
-
-Usage:
+Direct CSS pseudo selectors use `$` before the colon:
 
 ```ts
 pika({
-  color: 'red',
-  ':hover': { color: 'blue' },
-  '@dark': { color: 'white' },
-  '@md': { 'font-size': '1.2rem' },
+  '$:hover': { opacity: '0.8' },
+  '$:focus-visible': { outline: '2px solid currentColor' },
+  '$::before': { content: '""' },
 })
 ```
 
----
+`$` represents the generated atomic class selector. Bare `:hover` is not the built-in direct pseudo syntax.
+
+### Direct at-rules
+
+CSS at-rules can be used directly:
+
+```ts
+pika({
+  '@media (min-width: 768px)': {
+    fontSize: '1.125rem',
+  },
+  '@supports (display: grid)': {
+    display: 'grid',
+  },
+})
+```
+
+### Named selector aliases
+
+Register reusable aliases under `selectors.definitions`:
+
+```ts
+export default defineEngineConfig({
+  selectors: {
+    definitions: [
+      ['@dark', 'html.dark $'],
+      ['@motion-safe', '@media (prefers-reduced-motion: no-preference)'],
+      ['@group-hover', '.group:hover $'],
+    ],
+  },
+})
+```
+
+```ts
+pika({
+  '@dark': { color: 'white' },
+  '@motion-safe': { transition: 'opacity 150ms' },
+})
+```
+
+Aliases may also be dynamic rules using a `RegExp`, resolver, and optional autocomplete patterns. Read the package API before inventing a dynamic rule shape.
 
 ## Shortcuts
 
-Named style bundles reusable in pika() calls:
+Static and dynamic shortcuts live under `shortcuts.definitions`:
 
 ```ts
-shortcuts: {
-  definitions: [
-    ['flex-center', { display: 'flex', 'align-items': 'center', 'justify-content': 'center' }],
-    ['card', {
-      padding: '1rem',
-      'border-radius': '8px',
-      'box-shadow': '0 2px 4px rgba(0,0,0,0.1)',
-      '@dark': { 'background-color': '#2a2a2a' },
-    }],
-  ],
+export default defineEngineConfig({
+  shortcuts: {
+    definitions: [
+      ['flex-center', {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }],
+      ['button', {
+        padding: '0.5rem 1rem',
+        borderRadius: '0.375rem',
+        '$:hover': { opacity: '0.8' },
+      }],
+      [/^size-(.+)$/, ([, size]) => ({
+        width: size,
+        height: size,
+      }), 'size-${length}'],
+    ],
+  },
+})
+```
+
+Use them as style items:
+
+```ts
+pika('flex-center', 'button', { gap: '0.5rem' })
+```
+
+Unresolved strings are preserved as raw/existing class names, so a `pika()` call may combine PikaCSS shortcuts and ordinary classes.
+
+### `__shortcut`
+
+Expand shortcuts inside a style definition:
+
+```ts
+pika({
+  __shortcut: ['flex-center', 'button'],
+  backgroundColor: 'navy',
+  gap: '1rem',
+})
+```
+
+Shortcut declarations are inserted before the definition's own declarations, so explicit properties win. `__important` propagates to shortcut-expanded declarations.
+
+## Layer Control
+
+Define custom layers and set one per style definition:
+
+```ts
+export default defineEngineConfig({
+  layers: {
+    reset: 0,
+    preflights: 1,
+    components: 5,
+    utilities: 10,
+  },
+})
+```
+
+```ts
+pika({
+  __layer: 'components',
+  display: 'flex',
+})
+```
+
+The layer should exist in `config.layers`; numeric weights determine output order.
+
+## Important Control
+
+Per-definition:
+
+```ts
+pika({
+  __important: true,
+  color: 'red',
+})
+```
+
+Global default:
+
+```ts
+important: {
+  default: true,
 }
 ```
 
-Shortcuts can contain nested selectors. Use in code: `pika('flex-center', 'card')`
-
----
-
-## Per-Style Layer Control
-
-Override the default utility layer for individual styles using the `__layer` property:
-
-```ts
-pika({ __layer: 'components', display: 'flex', padding: '1rem' })
-```
-
-The layer must be defined in the `layers` config.
-
----
-
-## Per-Style !important
-
-Force `!important` on individual styles:
-
-```ts
-pika({ __important: true, color: 'red' })
-```
-
-Or globally via config:
-
-```ts
-important: { default: true }
-```
-
----
+Core plugin ordering ensures `!important` is applied after shortcut expansion and never to the `__shortcut` pseudo-property itself.
 
 ## CSS Property Syntax
 
-Both notations are accepted in StyleDefinition:
+Both camelCase and kebab-case are valid:
 
 ```ts
-// camelCase (JavaScript convention)
-pika({ fontSize: '16px', marginTop: '1rem' })
-
-// kebab-case (CSS convention)
-pika({ 'font-size': '16px', 'margin-top': '1rem' })
+pika({
+  fontSize: '16px',
+  marginTop: '1rem',
+  'line-height': '1.5',
+  '--local-gap': '0.5rem',
+})
 ```
 
-### Value Formats
+### Value fallbacks
 
-- **String**: `'16px'`, `'red'`, `'var(--color-primary)'`
-- **Tuple with fallback**: `['oklch(0.7 0.15 200)', ['blue']]` → rendered as `oklch(0.7 0.15 200), blue`
-- **CSS custom properties**: `{ '--my-var': '10px' }` (set inline custom properties)
+The fallback shape is `[primaryValue, fallbackValues[]]`:
 
----
+```ts
+pika({
+  color: ['oklch(0.7 0.15 220)', ['rgb(0 120 255)', 'blue']],
+})
+```
+
+PikaCSS emits fallback declarations first, then the primary declaration:
+
+```css
+color: blue;
+color: rgb(0 120 255);
+color: oklch(0.7 0.15 220);
+```
+
+A flat array such as `['blue', 'red']` is not the property fallback tuple.
+
+### Nullish values
+
+`null` or `undefined` removes/unsets a property during optimization. This is useful when transformed style definitions intentionally cancel an earlier value.
 
 ## Typed Config Fragments
 
-For reusable customization fragments, use plain object literals plus `satisfies` or explicit type annotations. Legacy wrapper helpers should not be suggested anymore.
+Only `defineEngineConfig` and `defineEnginePlugin` remain as public define helpers. For reusable fragments, use object literals with `satisfies` or explicit types:
 
 ```ts
-import type { StyleDefinition, VariablesDefinition } from '@pikacss/core'
+import type {
+  SelectorsConfig,
+  ShortcutsConfig,
+  StyleDefinition,
+  VariablesDefinition,
+} from '@pikacss/core'
 
-const cardStyle: StyleDefinition = { padding: '1rem', 'border-radius': '8px' }
+const cardStyle: StyleDefinition = {
+  padding: '1rem',
+  borderRadius: '0.5rem',
+}
+
 const themeVariables = {
   '--color-primary': '#3b82f6',
   '.dark': {
     '--color-primary': '#60a5fa',
   },
 } satisfies VariablesDefinition
+
+const selectors = {
+  definitions: [['@dark', 'html.dark $']],
+} satisfies SelectorsConfig
+
+const shortcuts = {
+  definitions: [['card', cardStyle]],
+} satisfies ShortcutsConfig
 ```
 
-Apply the same rule to preflights, keyframes, selectors, and shortcuts: write the config value directly in the shape documented above instead of wrapping it in a helper.
+Apply the same approach to preflights, keyframes, autocomplete, and official-plugin config. Do not suggest removed legacy wrapper helpers.

--- a/skills/pikacss-use/references/customizations.md
+++ b/skills/pikacss-use/references/customizations.md
@@ -348,11 +348,11 @@ pika({
 })
 ```
 
-PikaCSS emits fallback declarations first, then the primary declaration:
+PikaCSS emits fallback declarations in the supplied array order, then the primary declaration:
 
 ```css
-color: blue;
 color: rgb(0 120 255);
+color: blue;
 color: oklch(0.7 0.15 220);
 ```
 

--- a/skills/pikacss-use/references/plugin-design-tokens.md
+++ b/skills/pikacss-use/references/plugin-design-tokens.md
@@ -1,0 +1,224 @@
+# Plugin: Design Tokens
+
+> Read this when the user asks about W3C design token JSON, `design.md` token blocks, inline tokens, themes, aliases, CSS variable generation, token pruning, file watching, or neutral versus Node.js runtime adapters.
+
+## Installation
+
+```bash
+pnpm add -D @pikacss/plugin-design-tokens
+```
+
+## Choose the Correct Entry
+
+| Import | Capabilities |
+|---|---|
+| `@pikacss/plugin-design-tokens` | Inline token objects; file sources only when custom runtime capabilities are passed |
+| `@pikacss/plugin-design-tokens/node` | Inline tokens plus JSON and Markdown file sources resolved with Node.js filesystem APIs |
+
+Use `/node` in ordinary bundler config when `sources` contains paths:
+
+```ts
+// pika.config.ts
+import { defineEngineConfig } from '@pikacss/core'
+import { designTokens } from '@pikacss/plugin-design-tokens/node'
+
+export default defineEngineConfig({
+  plugins: [designTokens()],
+  designTokens: {
+    sources: ['./design.tokens.json'],
+  },
+})
+```
+
+Using a string source with the neutral entry produces a diagnostic and skips that source unless a custom `readFile` capability was supplied.
+
+## Inline Tokens
+
+The neutral entry works with inline W3C-style token groups:
+
+```ts
+import { designTokens } from '@pikacss/plugin-design-tokens'
+
+export default defineEngineConfig({
+  plugins: [designTokens()],
+  designTokens: {
+    sources: {
+      color: {
+        primary: { $value: '#3b82f6', $type: 'color' },
+        accent: { $value: '{color.primary}' },
+      },
+    },
+  },
+})
+```
+
+This generates variables such as `--color-primary` and `--color-accent` through the core variables system.
+
+## File Sources
+
+With the Node adapter:
+
+- Paths ending in `.md` are parsed as design documents.
+- Other paths are parsed as W3C design token JSON.
+- Relative paths resolve against `designTokens.root`, then the runtime working directory.
+- Missing paths are still registered as config dependencies so creating the file later can trigger a reload.
+- Invalid or unreadable sources emit structured diagnostics and are skipped rather than partially crashing token resolution.
+
+```ts
+export default defineEngineConfig({
+  plugins: [designTokens()],
+  designTokens: {
+    root: './design',
+    sources: ['tokens.json', 'components.md'],
+  },
+})
+```
+
+## Markdown Token Blocks
+
+Only fenced blocks whose info string starts with `tokens` are parsed:
+
+````md
+# Buttons
+
+```tokens
+{
+  "color": {
+    "primary": { "$value": "#3b82f6" }
+  }
+}
+```
+
+```tokens theme=dark selector="[data-theme='dark']"
+{
+  "color": {
+    "primary": { "$value": "#60a5fa" }
+  }
+}
+```
+````
+
+Supported fence attributes:
+
+- `theme=<name>` assigns a block to a theme.
+- `selector=<css-selector>` overrides that theme block's selector.
+
+Malformed JSON blocks are skipped with diagnostics.
+
+## Themes
+
+Base variables are emitted under `:root`. Theme variables use:
+
+1. A selector specified on the Markdown token block.
+2. `themes.<name>.selector` from config.
+3. The default `.<themeName>` selector.
+
+```ts
+export default defineEngineConfig({
+  plugins: [designTokens()],
+  designTokens: {
+    sources: ['./tokens.json'],
+    themes: {
+      dark: {
+        selector: '[data-theme="dark"]',
+        sources: ['./tokens.dark.json'],
+      },
+    },
+  },
+})
+```
+
+Later sources override earlier sources when generated variable names collide.
+
+## Config Reference
+
+| Option | Purpose | Default |
+|---|---|---|
+| `sources` | Inline token groups or file paths for `:root` | — |
+| `themes` | Theme selectors and token sources keyed by theme name | — |
+| `prefix` | Prefix inserted into generated variable names, without `--` | `''` |
+| `root` | Base path for relative file sources | Runtime cwd; `'.'` without one |
+| `pruneUnused` | Per-token override for variable pruning | Inherits the variables config default |
+
+## Names and Aliases
+
+Each path segment is normalized to kebab-case and joined with `-`:
+
+- `color.primary` → `--color-primary`
+- `fontSize.body` → `--font-size-body`
+- With `prefix: 'app'`: `color.primary` → `--app-color-primary`
+
+String token values may reference another token:
+
+```json
+{
+  "color": {
+    "primary": { "$value": "#3b82f6" },
+    "border": { "$value": "1px solid {color.primary}" }
+  }
+}
+```
+
+The alias becomes `var(--color-primary)` using the same normalization and prefix.
+
+## Composite Values
+
+Dedicated serializers exist for:
+
+- `shadow`
+- `border`
+- `transition`
+- Arrays, whose serialized items are joined with `, `
+
+An object value without a dedicated serializer is expanded into sub-variables. For example, a typography object with `fontSize` creates a `...-font-size` variable.
+
+## Pruning and Usage
+
+Tokens are inserted into `variables.definitions`, so they inherit:
+
+- Variable scoping.
+- Generated autocomplete.
+- Unused-variable pruning.
+
+Reference a token from normal styles:
+
+```ts
+pika({
+  color: 'var(--color-primary)',
+  borderColor: 'var(--color-border)',
+})
+```
+
+Set `designTokens.pruneUnused: false` when all generated token variables must remain even when PikaCSS cannot observe a reference.
+
+## Runtime Capabilities for Custom Hosts
+
+The neutral factory accepts optional runtime capabilities:
+
+```ts
+import { designTokens } from '@pikacss/plugin-design-tokens'
+
+const plugin = designTokens({
+  readFile: async absolutePath => customFilesystem.readText(absolutePath),
+  cwd: () => '/project',
+})
+```
+
+Use this only for non-Node hosts or custom integrations. Application bundler config should normally use the `/node` entry instead.
+
+## Diagnostics and File Watching
+
+The plugin reports structured diagnostics through the current engine's diagnostic handler. File-backed sources register every resolved path with `engine.addConfigDependency`, including missing paths, so official integrations can recreate the engine after changes.
+
+When testing failures, pass `onDiagnostic` to `createEngine` and assert diagnostic codes such as file-loader unavailable, read failure, invalid JSON, or unsupported value. Do not rely on console spying.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| File source is skipped | Neutral entry used | Import from `@pikacss/plugin-design-tokens/node` |
+| Relative path resolves incorrectly | Wrong root or integration cwd | Set `designTokens.root` explicitly |
+| Theme variables use the wrong selector | Fence selector/config selector mismatch | Align the selector with the application's actual theme mechanism |
+| Token variable is missing from output | Unused-variable pruning | Reference the variable or set `pruneUnused: false` |
+| Alias points to an unexpected name | Prefix/path normalization misunderstood | Apply the same prefix and kebab-case path rules to the target |
+| Editing a source does not reload | Custom host does not watch config dependencies | Ensure the integration watches `engine.configDependencies` |

--- a/skills/pikacss-use/references/plugin-development.md
+++ b/skills/pikacss-use/references/plugin-development.md
@@ -133,7 +133,7 @@ return defineEnginePlugin({
       to: { opacity: '1' },
     }])
     engine.variables.add({ '--my-color': 'rebeccapurple' })
-    engine.appendCssImport('url("https://example.test/fonts.css")')
+    engine.appendCssImport('@import url("https://example.test/fonts.css")')
   },
 })
 ```
@@ -174,7 +174,7 @@ Common methods available in `configureEngine`:
 |---|---|
 | `engine.addPreflight(preflight)` | Add raw, object, function, or wrapped preflight CSS |
 | `engine.appendAutocomplete(contribution)` | Add selector, shortcut, property, CSS-property, value, or pattern completions |
-| `engine.appendCssImport(cssImport)` | Add a CSS `@import` |
+| `engine.appendCssImport(cssImport)` | Add a raw CSS `@import` statement |
 | `engine.selectors.add(...selectors)` | Register static/dynamic selector rules |
 | `engine.shortcuts.add(...shortcuts)` | Register static/dynamic shortcut rules |
 | `engine.keyframes.add(...keyframes)` | Register keyframe definitions |

--- a/skills/pikacss-use/references/plugin-development.md
+++ b/skills/pikacss-use/references/plugin-development.md
@@ -1,21 +1,10 @@
 # Plugin Development
 
-> Read this when the user wants to create a new PikaCSS engine plugin, modify an existing plugin's internals, understand plugin hooks and lifecycle, extend EngineConfig with module augmentation, or write plugin tests.
-
-## Table of Contents
-
-1. [Plugin Structure](#plugin-structure)
-2. [Lifecycle Hooks](#lifecycle-hooks)
-3. [Engine API](#engine-api)
-4. [Config Augmentation](#config-augmentation)
-5. [Real-World Example (plugin-reset)](#real-world-example-plugin-reset)
-6. [Testing](#testing)
-
----
+> Read this when creating or modifying a PikaCSS engine plugin, selecting lifecycle hooks, extending config types, reporting diagnostics, loading external files, designing runtime adapters, or writing plugin tests.
 
 ## Plugin Structure
 
-Plugins are plain objects with a `name`, optional `order`, and **direct hook methods** (no `setup()` wrapper):
+Plugins are plain objects created with `defineEnginePlugin`. Hooks are direct object methods; there is no `setup()` wrapper.
 
 ```ts
 import type { EnginePlugin } from '@pikacss/core'
@@ -24,136 +13,252 @@ import { defineEnginePlugin } from '@pikacss/core'
 export function myPlugin(): EnginePlugin {
   return defineEnginePlugin({
     name: 'my-plugin',
-    order: 'pre', // 'pre' | undefined | 'post'
+    order: 'pre',
 
-    // hooks go directly on the object:
-    configureRawConfig: (config) => {
-      // ...
+    configureRawConfig(config, context) {
+      // Compose defaults before config resolution.
+      return config
     },
-    configureEngine: async (engine) => {
-      // ...
+
+    async configureEngine(engine) {
+      // Register runtime behavior after engine creation.
+      engine.reportDiagnostic({
+        level: 'warning',
+        code: 'my-plugin-example',
+        message: 'Example diagnostic',
+        plugin: 'my-plugin',
+      })
     },
   })
 }
 ```
 
-When writing generic examples, keep the plugin factory name aligned across every snippet. If the example defines `myPlugin`, the consumer config and tests should use `plugins: [myPlugin()]` rather than switching to a different placeholder name.
+Keep factory names consistent across implementation, consumer examples, and tests. If the factory is `myPlugin`, always show `plugins: [myPlugin()]`.
 
-**Order tiers**: `'pre'` → default (`undefined`) → `'post'`. Within a tier, original array order is preserved. There is no `'normal'` value.
+## Ordering
 
-`defineEnginePlugin` is an identity helper for type inference only.
+Plugin order tiers are:
+
+1. `'pre'`
+2. Default (`undefined`)
+3. `'post'`
+
+Original array order is preserved within a tier. There is no `'normal'` value.
+
+Core plugins are installed automatically by `createEngine`; application plugins are combined with them and sorted by these tiers.
+
+## Hook Context and Diagnostics
+
+Every lifecycle hook receives an optional `EnginePluginContext`:
+
+```ts
+interface EnginePluginContext {
+  onDiagnostic: DiagnosticHandler
+}
+```
+
+For hooks with payloads, it is the second argument. For payload-less notification hooks, it is the first argument.
+
+```ts
+configureRawConfig(config, context) {
+  context?.onDiagnostic({
+    level: 'warning',
+    code: 'my-plugin-deprecated-option',
+    message: 'The old option is deprecated.',
+    plugin: 'my-plugin',
+    hook: 'configureRawConfig',
+  })
+}
+
+preflightUpdated(context) {
+  // context?.onDiagnostic(...)
+}
+```
+
+Diagnostics are structured data. Do not assume `console`, Node.js, or a browser exists in a core plugin. Include a stable `code`, human-readable `message`, severity, and relevant `plugin`, `hook`, or `cause` metadata.
+
+A host diagnostic handler is isolated: if it throws, it does not replace the engine result. A plugin hook that throws is reported as a `plugin-hook-error` diagnostic and then rethrown; failed lifecycle execution is not silently converted into a partial result.
 
 ## Lifecycle Hooks
 
-All hooks are direct methods on the plugin object.
-
-| Hook | Sync/Async | Signature |
+| Hook | Signature | Primary use |
 |---|---|---|
-| `configureRawConfig` | async | `(config: EngineConfig) => Awaitable<EngineConfig \| void>` |
-| `rawConfigConfigured` | sync | `(config: EngineConfig) => void` |
-| `configureResolvedConfig` | async | `(resolvedConfig: ResolvedEngineConfig) => Awaitable<ResolvedEngineConfig \| void>` |
-| `configureEngine` | async | `(engine: Engine) => Awaitable<Engine \| void>` |
-| `transformSelectors` | async | `(selectors: string[]) => Awaitable<string[] \| void>` |
-| `transformStyleItems` | async | `(styleItems: ResolvedStyleItem[]) => Awaitable<ResolvedStyleItem[] \| void>` |
-| `transformStyleDefinitions` | async | `(styleDefinitions: ResolvedStyleDefinition[]) => Awaitable<ResolvedStyleDefinition[] \| void>` |
-| `preflightUpdated` | sync | `() => void` |
-| `atomicStyleAdded` | sync | `(atomicStyle: AtomicStyle) => void` |
-| `autocompleteConfigUpdated` | sync | `() => void` |
+| `configureRawConfig` | `(config, context?) => Awaitable<EngineConfig \| void>` | Add defaults or compose raw user config |
+| `rawConfigConfigured` | `(config, context?) => EngineConfig \| void` | Observe or synchronously adjust config after all raw-config hooks |
+| `configureResolvedConfig` | `(resolvedConfig, context?) => Awaitable<ResolvedEngineConfig \| void>` | Adjust fully resolved config |
+| `configureEngine` | `(engine, context?) => Awaitable<Engine \| void>` | Register engine services, preflights, resolvers, autocomplete, imports, or dependencies |
+| `transformSelectors` | `(selectors, context?) => Awaitable<string[] \| void>` | Transform resolved selector strings |
+| `transformStyleItems` | `(styleItems, context?) => Awaitable<ResolvedStyleItem[] \| void>` | Modify or expand resolved style items |
+| `transformStyleDefinitions` | `(definitions, context?) => Awaitable<ResolvedStyleDefinition[] \| void>` | Modify flattened style definitions |
+| `preflightUpdated` | `(context?) => void` | Observe changes affecting rendered preflight CSS |
+| `atomicStyleAdded` | `(atomicStyle, context?) => AtomicStyle \| void` | Observe a newly registered atomic style |
+| `autocompleteConfigUpdated` | `(context?) => void` | Observe autocomplete changes |
 
-Returning `void`/`null`/`undefined` keeps the current payload unchanged.
+For payload hooks, returning `undefined` or `null` keeps the current payload. Returning a replacement payload pipes it into the next plugin.
 
-### Config Phase
+### Configuration phase
 
-Runs once during engine initialization, in order:
+The engine runs:
 
-1. **`configureRawConfig`** — Mutate or replace the raw user config before resolution. Good for injecting defaults (layers, preflight layers, fallback options).
-2. **`rawConfigConfigured`** — Read-only observation after all plugins have configured the raw config.
-3. **`configureResolvedConfig`** — Mutate or replace the resolved config. Runs after internal resolution logic.
-4. **`configureEngine`** — Access the fully initialized engine. Register preflights, selectors, shortcuts, keyframes, variables, autocomplete, and CSS imports here.
+1. `configureRawConfig`
+2. `rawConfigConfigured`
+3. Core config resolution
+4. `configureResolvedConfig`
+5. Engine construction
+6. `configureEngine`
 
-```ts
-configureRawConfig: (config) => {
-  config.layers ??= {}
-  config.layers.myLayer = 5
-},
-
-configureEngine: async (engine) => {
-  // addPreflight: plain string
-  engine.addPreflight('*, *::before, *::after { box-sizing: border-box; }')
-  // addPreflight: wrapped with layer and id
-  engine.addPreflight({ layer: 'myLayer', id: 'my-reset', preflight: '/* CSS */' })
-  engine.selectors.add(['$:custom', '&:is(:hover, :focus)'])
-  engine.shortcuts.add(['my-shortcut', { display: 'flex' }])
-  engine.keyframes.add(['fade-in', { from: { opacity: '0' }, to: { opacity: '1' } }])
-  engine.variables.add({ '--my-var': 'red' })
-},
-```
-
-### Transform Phase
-
-Runs each time `pika()` calls are processed:
-
-5. **`transformSelectors`** — Modify selector strings before they are applied.
-6. **`transformStyleItems`** — Modify or expand resolved style items.
-7. **`transformStyleDefinitions`** — Modify resolved style definitions after flattening.
+Use `configureRawConfig` when the plugin's feature must participate in normal core config resolution. Use `configureEngine` when registering runtime state or services on the initialized engine.
 
 ```ts
-transformStyleItems: async (styleItems) => {
-  // modify or expand resolved style items
-  return styleItems
-},
+return defineEnginePlugin({
+  name: 'my-plugin',
+  order: 'pre',
 
-transformStyleDefinitions: async (styleDefinitions) => {
-  // modify resolved style definitions
-  return styleDefinitions
-},
+  configureRawConfig(config) {
+    config.layers ??= {}
+    config.layers.myLayer ??= 5
+  },
+
+  configureEngine(engine) {
+    engine.addPreflight({
+      id: 'my-plugin-base',
+      layer: 'myLayer',
+      preflight: '*, *::before, *::after { box-sizing: border-box; }',
+    })
+
+    engine.selectors.add(['@reduced-motion', '@media (prefers-reduced-motion: reduce)'])
+    engine.shortcuts.add(['my-stack', { display: 'flex', flexDirection: 'column' }])
+    engine.keyframes.add(['fade-in', {
+      from: { opacity: '0' },
+      to: { opacity: '1' },
+    }])
+    engine.variables.add({ '--my-color': 'rebeccapurple' })
+    engine.appendCssImport('url("https://example.test/fonts.css")')
+  },
+})
 ```
 
-### Notification Hooks
+### Transform phase
 
-Fire after engine state changes:
+Transform hooks run whenever style calls are processed:
 
-8. **`preflightUpdated`** — After preflight CSS changes.
-9. **`atomicStyleAdded`** — After a new atomic style is registered.
-10. **`autocompleteConfigUpdated`** — After autocomplete contributions change.
+```ts
+return defineEnginePlugin({
+  name: 'my-transform',
+
+  transformStyleItems(styleItems) {
+    return styleItems
+  },
+
+  transformStyleDefinitions(definitions) {
+    return definitions
+  },
+
+  transformSelectors(selectors) {
+    return selectors
+  },
+})
+```
+
+Avoid mutating shared objects without a clear ownership contract. Returning a new array is easier to reason about when adding or removing items.
+
+### Notification hooks
+
+Notification hooks observe engine state changes. They should remain lightweight and must not assume their return value changes the caller's state.
 
 ## Engine API
 
-Methods available on the `engine` object in `configureEngine`:
+Common methods available in `configureEngine`:
 
 | Method | Purpose |
 |---|---|
-| `engine.addPreflight(preflight)` | Add preflight CSS — accepts a plain CSS string, a `PreflightDefinition` (CSS declaration object), a `PreflightFn` (function returning CSS), or a wrapped `{ id?, layer?, preflight }` object |
-| `engine.appendAutocomplete(contribution)` | Add autocomplete suggestions — `AutocompleteContribution` has optional fields: `selectors`, `shortcuts`, `extraProperties`, `extraCssProperties`, `properties`, `cssProperties`, `patterns` |
-| `engine.appendCssImport(cssImport)` | Add CSS `@import` |
-| `engine.selectors.add(...selectors)` | Register named selectors — each arg is a `Selector`: `[name, cssSelector]` tuple or `{ selector, value }` object |
-| `engine.shortcuts.add(...shortcuts)` | Register named shortcuts — each arg is a `Shortcut`: `[name, styleItems]` tuple or `{ shortcut, value }` object |
-| `engine.keyframes.add(...keyframes)` | Register named keyframes — each arg is a `Keyframes`: `[name, frames]` tuple or `{ name, frames }` object |
-| `engine.variables.add(variables)` | Register CSS custom properties — arg is a `VariablesDefinition` record: `{ '--key': 'value', 'html.dark': { '--key': 'dark-value' } }` |
-| `engine.use(...items)` | Process style items through the engine |
+| `engine.addPreflight(preflight)` | Add raw, object, function, or wrapped preflight CSS |
+| `engine.appendAutocomplete(contribution)` | Add selector, shortcut, property, CSS-property, value, or pattern completions |
+| `engine.appendCssImport(cssImport)` | Add a CSS `@import` |
+| `engine.selectors.add(...selectors)` | Register static/dynamic selector rules |
+| `engine.shortcuts.add(...shortcuts)` | Register static/dynamic shortcut rules |
+| `engine.keyframes.add(...keyframes)` | Register keyframe definitions |
+| `engine.variables.add(variables)` | Register CSS variables and scopes |
+| `engine.use(...styleItems)` | Resolve style items and register atomic styles |
+| `engine.reportDiagnostic(diagnostic)` | Deliver a structured diagnostic through this engine's host handler |
+| `engine.addConfigDependency(path)` | Register an external file that integrations must watch |
 
-Render methods (primarily for testing):
+Rendering methods used primarily by tests and integrations:
 
 | Method | Purpose |
 |---|---|
-| `engine.renderPreflights(isFormatted)` | Render preflight CSS |
-| `engine.renderAtomicStyles(isFormatted, options?)` | Render atomic CSS |
-| `engine.renderLayerOrderDeclaration()` | Render `@layer` ordering |
+| `engine.renderPreflights(isFormatted)` | Render imports, layers, and preflight-contributed CSS |
+| `engine.renderAtomicStyles(isFormatted, options?)` | Render atomic utility CSS |
+| `engine.renderLayerOrderDeclaration()` | Render the `@layer` ordering declaration |
+
+## External File Dependencies
+
+A plugin that reads files must register every resolved path:
+
+```ts
+configureEngine(engine) {
+  engine.addConfigDependency('/project/design/tokens.json')
+}
+```
+
+Official integrations watch `engine.configDependencies` and recreate the engine when a dependency changes. Register a missing expected path before reading it when creating that file later should also trigger reload.
+
+Do not rely only on watching the main `pika.config.*` file. Without `addConfigDependency`, edits to secondary files remain invisible to the integration.
+
+## Platform-Neutral Plugins and Runtime Adapters
+
+Keep the neutral entry free of unconditional Node.js/browser APIs. Inject host capabilities into the plugin factory and expose platform adapters as explicit subpath exports when necessary.
+
+```ts
+export interface MyRuntimeOptions {
+  readFile?: (absolutePath: string) => Promise<string>
+  cwd?: () => string
+}
+
+export function myPlugin(runtime: MyRuntimeOptions = {}): EnginePlugin {
+  // Use only supplied capabilities here.
+  return defineEnginePlugin({
+    name: 'my-plugin',
+  })
+}
+```
+
+```ts
+// node.ts
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+import { myPlugin as createMyPlugin } from './index'
+
+export * from './index'
+
+export function myPlugin() {
+  return createMyPlugin({
+    readFile: path => readFile(path, 'utf8'),
+    cwd: () => process.cwd(),
+  })
+}
+```
+
+Use a package export such as `./node` for the adapter. This keeps core behavior reusable in neutral hosts and makes platform capabilities explicit to consumers.
 
 ## Config Augmentation
 
-Extend `EngineConfig` via TypeScript module augmentation so users can configure your plugin in `pika.config.ts`:
+Extend `EngineConfig` through module augmentation:
 
 ```ts
+export interface MyPluginConfig {
+  enabled?: boolean
+  source?: string
+}
+
 declare module '@pikacss/core' {
   interface EngineConfig {
-    /** My plugin option. @default 'hello' */
-    myOption?: string
+    myPlugin?: MyPluginConfig
   }
 }
 ```
 
-Users then configure via:
+Consumers import the plugin package, which loads the augmentation:
 
 ```ts
 import { defineEngineConfig } from '@pikacss/core'
@@ -161,79 +266,76 @@ import { myPlugin } from 'my-plugin'
 
 export default defineEngineConfig({
   plugins: [myPlugin()],
-  myOption: 'custom-value',
+  myPlugin: {
+    enabled: true,
+    source: './my-plugin.json',
+  },
 })
 ```
 
-## Real-World Example (plugin-reset)
+Keep runtime behavior gated by plugin registration. Importing a package may make types visible, but configuration should not take effect unless the factory is in `plugins`.
 
-```ts
-import type { EnginePlugin } from '@pikacss/core'
-import { defineEnginePlugin } from '@pikacss/core'
-
-declare module '@pikacss/core' {
-  interface EngineConfig {
-    reset?: ResetStyle
-  }
-}
-
-export function reset(): EnginePlugin {
-  let style: ResetStyle = 'modern-normalize'
-  return defineEnginePlugin({
-    name: 'reset',
-    order: 'pre',
-    configureRawConfig: (config) => {
-      if (config.reset) style = config.reset
-      config.layers ??= {}
-      config.layers.reset = -1
-    },
-    configureEngine: async (engine) => {
-      const resetCss = resetStyles[style]
-      if (resetCss) {
-        engine.addPreflight({ layer: 'reset', preflight: resetCss })
-      }
-    },
-  })
-}
-```
+Plugins may also augment `Engine` when they install a runtime service, but initialize the property before another hook can consume it and document ordering requirements.
 
 ## Testing
 
-Use `createEngine` from `@pikacss/core` with Vitest:
+Use `createEngine` from `@pikacss/core`.
 
 ```ts
+import type { Diagnostic } from '@pikacss/core'
 import { createEngine, defineEngineConfig } from '@pikacss/core'
+import { expect, it } from 'vitest'
 import { myPlugin } from '../src'
 
-it('should register preflights', async () => {
+it('registers its preflight', async () => {
   const engine = await createEngine(defineEngineConfig({
     plugins: [myPlugin()],
   }))
-  const css = await engine.renderPreflights(false)
-  expect(css).toContain('/* expected CSS */')
+
+  expect(await engine.renderPreflights(false)).toContain('box-sizing:border-box')
 })
 
-it('should register shortcuts', async () => {
-  const engine = await createEngine(defineEngineConfig({
+it('registers shortcuts', async () => {
+  const engine = await createEngine({
     plugins: [myPlugin()],
-  }))
-  const result = await engine.use({ display: 'flex' }, 'my-shortcut')
-  const css = await engine.renderAtomicStyles(false)
-  expect(css).toContain('display:flex')
+  })
+
+  await engine.use('my-stack')
+  expect(await engine.renderAtomicStyles(false)).toContain('display:flex')
 })
 
-it('should augment config', async () => {
-  const engine = await createEngine(defineEngineConfig({
+it('emits structured diagnostics', async () => {
+  const diagnostics: Diagnostic[] = []
+
+  await createEngine({
     plugins: [myPlugin()],
-    myOption: 'custom-value',
+  }, {
+    onDiagnostic: diagnostic => diagnostics.push(diagnostic),
+  })
+
+  expect(diagnostics).toContainEqual(expect.objectContaining({
+    code: 'my-plugin-example',
+    plugin: 'my-plugin',
   }))
-  // verify plugin read the augmented config
+})
+
+it('registers external dependencies', async () => {
+  const engine = await createEngine({
+    plugins: [myPlugin()],
+  })
+
+  expect(engine.configDependencies).toContain('/project/design/tokens.json')
 })
 ```
 
-### Testing Tips
+### Test checklist
 
-- Use `engine.renderPreflights(false)` and `engine.renderAtomicStyles(false)` (unformatted) for simpler snapshot matching.
-- Call `engine.use(...)` to feed style items through the engine before rendering atomic styles.
-- Test config augmentation by passing augmented options to `defineEngineConfig` and asserting the plugin consumed them correctly.
-- Test hook ordering by combining your plugin with a simple spy plugin that records hook invocations.
+- Normal config and default behavior.
+- Config augmentation typechecks.
+- Every diagnostic branch asserts stable codes and metadata.
+- External files appear in `engine.configDependencies`.
+- Hook ordering is tested with multiple small spy plugins.
+- Returning replacement hook payloads is covered when used.
+- Thrown hooks reject engine creation and produce the expected `plugin-hook-error` diagnostic.
+- Neutral entry tests do not require Node globals; platform adapters receive separate tests.
+- Render unformatted CSS for simpler assertions unless formatting itself is under test.

--- a/skills/pikacss-use/references/plugin-fonts.md
+++ b/skills/pikacss-use/references/plugin-fonts.md
@@ -1,14 +1,12 @@
 # Plugin: Fonts
 
-> Read this when the user asks about web font loading, Google Fonts integration, custom @font-face, or font shortcuts.
+> Read this when the user asks about web-font providers, Google/Bunny/Fontshare/Coollabs loading, custom providers, self-hosted `@font-face`, raw imports, family stacks, or `font-*` shortcuts.
 
-## Installation
+## Installation and Setup
 
 ```bash
 pnpm add -D @pikacss/plugin-fonts
 ```
-
-## Setup
 
 ```ts
 // pika.config.ts
@@ -20,81 +18,199 @@ export default defineEngineConfig({
 })
 ```
 
-## Usage in pika()
+`fonts()` takes no arguments. Configure it through the top-level `fonts` key.
 
-Fonts creates `font-{token}` shortcuts:
+## Generated Shortcuts
+
+Every token under `fonts.fonts` or `fonts.families` creates a `font-{token}` shortcut backed by a `--pk-font-{token}` variable:
 
 ```ts
 pika('font-sans')
-pika('font-display', { 'font-weight': '700' })
+pika('font-display', { fontWeight: '700' })
 ```
 
-## Configuration
+## Provider Fonts
 
-Set via the `fonts` key on `EngineConfig`:
-
-### Google Fonts (default provider)
+The default provider is `google`:
 
 ```ts
 export default defineEngineConfig({
+  plugins: [fonts()],
   fonts: {
-    provider: 'google',  // default
+    provider: 'google',
+    display: 'swap',
     fonts: {
-      sans: 'Inter',
-      display: 'Playfair Display:400,700',
-      mono: [{ name: 'JetBrains Mono', weights: [400, 700] }],
+      sans: 'Inter:400,600,700',
+      display: {
+        name: 'Playfair Display',
+        weights: [400, 700],
+        italic: true,
+      },
+      mono: [
+        { name: 'JetBrains Mono', weights: [400, 700] },
+        'ui-monospace',
+      ],
     },
   },
-  plugins: [fonts()],
 })
 ```
 
-### Custom @font-face
+A token may map to one font entry or an array. Array entries are combined into the final family stack.
+
+### Built-in providers
+
+| Provider | Purpose |
+|---|---|
+| `google` | Google Fonts CSS API; default |
+| `bunny` | Bunny Fonts |
+| `fontshare` | Fontshare CSS API |
+| `coollabs` | Coollabs Google Fonts proxy |
+| `none` | No external request; useful for generic or already-loaded family names |
+
+A per-font `provider` overrides the global provider.
+
+### Font entry forms
+
+```ts
+fonts: {
+  fonts: {
+    simple: 'Roboto',
+    weighted: 'Roboto:400,700',
+    variable: 'Roboto Flex:100..900',
+    detailed: {
+      name: 'Roboto',
+      weights: [400, 700],
+      italic: true,
+      provider: 'bunny',
+      providerOptions: {
+        text: 'Hello',
+      },
+    },
+  },
+}
+```
+
+String weight syntax accepts individual values, comma-separated values, and variable-font ranges such as `100..900`.
+
+## Raw Family Stacks
+
+Use `families` when no provider loading is needed:
+
+```ts
+fonts: {
+  families: {
+    system: 'system-ui, sans-serif',
+    mono: ['ui-monospace', 'SFMono-Regular', 'monospace'],
+  },
+}
+```
+
+This still creates `font-system` and `font-mono` shortcuts.
+
+## Self-Hosted `@font-face`
 
 ```ts
 export default defineEngineConfig({
+  plugins: [fonts()],
   fonts: {
     faces: [
       {
         fontFamily: 'MyCustomFont',
-        src: 'url(/fonts/custom.woff2) format("woff2")',
-        fontWeight: '400',
+        src: [
+          'url(/fonts/custom.woff2) format("woff2")',
+          'url(/fonts/custom.woff) format("woff")',
+        ],
+        fontWeight: '100 900',
+        fontStyle: 'normal',
         fontDisplay: 'swap',
+        unicodeRange: 'U+0000-00FF',
       },
     ],
     fonts: {
-      brand: { name: 'MyCustomFont', provider: 'none' },
+      brand: {
+        name: 'MyCustomFont',
+        provider: 'none',
+      },
     },
   },
-  plugins: [fonts()],
 })
 ```
 
-### Raw @import
+Supported descriptors include `fontFamily`, `src`, `fontDisplay`, `fontWeight`, `fontStyle`, `fontStretch`, and `unicodeRange`.
+
+## Additional Imports
+
+`imports` accepts one URL or an array. The plugin wraps each value in an `@import url("...")` rule and places it before provider-generated imports:
 
 ```ts
-export default defineEngineConfig({
-  fonts: {
-    imports: ['url(https://fonts.googleapis.com/css2?family=Roboto&display=swap)'],
-    families: { sans: 'Roboto, sans-serif' },
+fonts: {
+  imports: [
+    'https://example.test/fonts.css',
+  ],
+  families: {
+    external: 'External Font, sans-serif',
   },
-  plugins: [fonts()],
-})
+}
 ```
 
-## Key Options
+Pass the URL itself, not a complete `@import` statement.
+
+## Config Reference
 
 | Option | Type | Default | Purpose |
 |---|---|---|---|
-| `provider` | `string` | `'google'` | Default font provider |
-| `fonts` | `Record<token, FontFamilyEntry>` | — | Font token definitions |
-| `families` | `Record<string, string>` | — | Raw CSS font-family stacks |
-| `faces` | `FontFaceDefinition[]` | — | Explicit @font-face rules |
-| `imports` | `string[]` | — | Raw @import rules |
-| `display` | `string` | `'swap'` | font-display value |
-| `providers` | `Record<string, Provider>` | — | Custom provider definitions |
+| `provider` | Built-in or custom provider name | `'google'` | Default provider |
+| `fonts` | `Record<string, FontFamilyEntry \| FontFamilyEntry[]>` | `{}` | Provider-loaded entries and shortcut tokens |
+| `families` | `Record<string, string \| string[]>` | `{}` | Raw family stacks and shortcut tokens |
+| `imports` | `string \| string[]` | `[]` | Additional stylesheet URLs |
+| `faces` | `FontFaceDefinition[]` | `[]` | Explicit `@font-face` rules |
+| `display` | `string` | `'swap'` | Display mode sent to providers |
+| `providers` | `Record<string, FontsProviderDefinition>` | `{}` | Custom provider implementations |
+| `providerOptions` | `Record<string, FontsProviderOptions>` | `{}` | Global options keyed by provider |
 
-### FontFamilyEntry
+Provider options are filtered by each provider. Current built-ins recognize `text`; unsupported keys are ignored.
 
-- **String form**: `'Roboto'` or `'Roboto:400,700'`
-- **Object form**: `{ name: 'Roboto', weights: [400, 700], italic: true, provider: 'google' }`
+## Custom Providers
+
+Use the package's `defineFontsProvider` helper:
+
+```ts
+import { defineEngineConfig } from '@pikacss/core'
+import { defineFontsProvider, fonts } from '@pikacss/plugin-fonts'
+
+const internal = defineFontsProvider({
+  buildImportUrls(entries, context) {
+    return entries.map(entry =>
+      `https://fonts.example.test/css?family=${encodeURIComponent(entry.name)}&display=${encodeURIComponent(context.display)}`,
+    )
+  },
+})
+
+export default defineEngineConfig({
+  plugins: [fonts()],
+  fonts: {
+    provider: 'internal',
+    providers: { internal },
+    fonts: {
+      sans: 'Example Sans:400,700',
+    },
+  },
+})
+```
+
+A custom provider may return one URL, multiple URLs, or no URL. Unknown provider names emit a structured diagnostic instead of silently loading from another provider.
+
+## Diagnostics
+
+Provider failures and invalid provider configuration are reported through the engine diagnostic channel. When testing custom providers, pass `onDiagnostic` to `createEngine` and assert diagnostic codes rather than spying on `console`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `font-*` shortcut is missing | Token is absent or plugin not registered | Add the token and use `plugins: [fonts()]` |
+| External request uses wrong provider | Global/per-font provider mismatch | Check the entry's `provider` override |
+| Self-hosted font still triggers a request | Entry uses a network provider | Set `provider: 'none'` or use `families` |
+| Provider option has no effect | Provider does not support that key | Check supported options; built-ins currently recognize `text` |
+| Family fallback order is wrong | Token entries/families are ordered incorrectly | Put entries in the desired CSS family order |
+| Raw import is malformed | Complete `@import` was supplied | Pass only the URL value |

--- a/skills/pikacss-use/references/plugin-icons.md
+++ b/skills/pikacss-use/references/plugin-icons.md
@@ -121,14 +121,14 @@ export default defineEngineConfig({
       // meta.source: 'custom' | 'local' | 'cdn'
       // meta.mode: final 'mask' or 'bg' mode
 
-      if (meta.source === 'cdn')
-        styleItem.opacity = '0.95'
+      if (meta.source === 'cdn' && typeof styleItem !== 'string')
+        Object.assign(styleItem, { opacity: '0.95' })
     },
   },
 })
 ```
 
-The callback mutates `styleItem` in place before the shortcut result is returned.
+The callback mutates `styleItem` in place before the shortcut result is returned. Although generated icon styles are objects at runtime, the public callback type is `StyleItem`, so examples should narrow away the string case before property mutation.
 
 ## Custom Collections and Reloading
 

--- a/skills/pikacss-use/references/plugin-icons.md
+++ b/skills/pikacss-use/references/plugin-icons.md
@@ -1,6 +1,6 @@
 # Plugin: Icons
 
-> Read this when the user asks about using icons with PikaCSS, icon rendering modes, icon sources, or troubleshooting missing icons.
+> Read this when the user asks about icon shortcuts, Iconify collections, local versus remote resolution, rendering modes, processor hooks, autocomplete, or missing icons.
 
 ## Installation
 
@@ -8,21 +8,39 @@
 pnpm add -D @pikacss/plugin-icons
 ```
 
-## Setup
+Install individual Iconify collections when local package resolution is desired:
+
+```bash
+pnpm add -D @iconify-json/lucide
+pnpm add -D @iconify-json/mdi
+```
+
+## Choose the Correct Entry
+
+The package has platform-neutral and Node.js entries:
+
+| Import | Capabilities |
+|---|---|
+| `@pikacss/plugin-icons` | Custom collections and configured CDN sources |
+| `@pikacss/plugin-icons/node` | Everything above plus locally installed `@iconify-json/*` packages and `autoInstall` |
+
+Bundler config normally runs in Node.js, so use `/node` when users expect installed icon collections to resolve:
 
 ```ts
 // pika.config.ts
 import { defineEngineConfig } from '@pikacss/core'
-import { icons } from '@pikacss/plugin-icons'
+import { icons } from '@pikacss/plugin-icons/node'
 
 export default defineEngineConfig({
   plugins: [icons()],
 })
 ```
 
-## Usage in pika()
+Using the neutral entry with only a locally installed collection does not load that package. It needs a custom collection, a CDN, or a custom runtime capability.
 
-Icons are used as shortcuts with the pattern `i-{collection}:{name}`:
+## Usage
+
+Icons are shortcuts with the form `i-{collection}:{name}`:
 
 ```ts
 pika('i-lucide:rocket')
@@ -30,59 +48,105 @@ pika('i-mdi:home')
 pika('i-lucide:rocket', { width: '24px', height: '24px' })
 ```
 
-## Icon Sources (precedence order)
-
-1. **Custom collections** — defined in config via `collections` option
-2. **Locally installed packages** — `@iconify-json/{collection}` npm packages
-3. **CDN fallback** — fetches from Iconify CDN if local package is missing
-
-### Installing icon collections
-
-```bash
-pnpm add -D @iconify-json/lucide    # Lucide icons
-pnpm add -D @iconify-json/mdi       # Material Design Icons
-```
-
-### Auto-install
-
-Set `autoInstall: true` in config to automatically install missing `@iconify-json/*` packages:
+Force a rendering mode per icon with a suffix:
 
 ```ts
-export default defineEngineConfig({
-  icons: { autoInstall: true },
-  plugins: [icons()],
-})
+pika('i-mdi:home?mask')
+pika('i-mdi:home?bg')
+pika('i-mdi:home?auto')
 ```
 
-## Configuration Options
+## Resolution Order
 
-Set via the `icons` key on `EngineConfig`:
+1. Custom collections from `icons.collections`.
+2. Locally installed packages when the Node adapter is active.
+3. The configured CDN.
+
+A missing or temporarily unavailable icon is reported but not permanently cached as a miss. Later resolutions retry, and failed CDN collection requests are removed from the cache before the next attempt.
+
+## Configuration
+
+Set options under the top-level `icons` key:
 
 | Option | Type | Default | Purpose |
 |---|---|---|---|
-| `prefix` | `string \| string[]` | `'i-'` | Shortcut prefix(es) |
-| `mode` | `'auto' \| 'mask' \| 'bg'` | `'auto'` | Rendering mode |
-| `scale` | `number` | `1` | Size multiplier |
-| `autoInstall` | `boolean` | `false` | Auto-install missing collections |
-| `collections` | `CustomCollections` | — | Custom SVG icon collections |
-| `cdn` | `string` | — | CDN URL template (`{collection}` placeholder) |
-| `unit` | `string` | — | CSS unit (e.g., `'em'`, `'rem'`) |
-| `extraProperties` | `Record<string, string>` | — | Extra CSS on every icon |
-| `customizations` | `IconifyCustomizations` | — | SVG processing hooks |
+| `prefix` | `string \| string[]` | `'i-'` | One or more shortcut prefixes |
+| `mode` | `'auto' \| 'mask' \| 'bg'` | `'auto'` | Rendering strategy |
+| `scale` | `number` | `1` | Intrinsic size multiplier |
+| `collections` | `CustomCollections` | — | Custom SVG maps or loaders |
+| `customizations` | `IconCustomizations` | `{}` | Iconify SVG transformation hooks |
+| `autoInstall` | Iconify loader option | `false` | Install missing local collections; requires `/node` |
+| `cwd` | Iconify loader option | — | Working directory for local package lookup; requires `/node` |
+| `cdn` | `string` | — | CDN template with `{collection}`, or a base URL |
+| `unit` | `string` | — | Explicit dimension unit such as `em` |
+| `extraProperties` | `Record<string, string>` | `{}` | CSS merged into every generated icon style |
+| `processor` | `(styleItem, meta) => void` | — | Mutate each generated style item using resolved metadata |
+| `autocomplete` | `string[]` | — | Explicit icon identifiers for generated completions |
 
-### Rendering Modes
+```ts
+export default defineEngineConfig({
+  plugins: [icons()],
+  icons: {
+    mode: 'auto',
+    scale: 1,
+    autocomplete: ['lucide:rocket', 'mdi:home'],
+    extraProperties: {
+      display: 'inline-block',
+      verticalAlign: 'middle',
+    },
+  },
+})
+```
 
-- **`'auto'`** — uses `mask` for monochrome icons, `bg` for colored icons
-- **`'mask'`** — renders as CSS mask-image (icon color follows `currentColor`)
-- **`'bg'`** — renders as background-image (preserves original colors)
+## Rendering Modes
 
-Force a mode per icon: `pika('i-mdi:home?mask')` or `pika('i-mdi:home?bg')`
+- `auto`: uses `mask` when the resolved SVG contains `currentColor`; otherwise uses `bg`.
+- `mask`: emits a CSS mask and follows `currentColor`.
+- `bg`: emits a background image and preserves the SVG's original colors.
+
+Do not describe `auto` merely as “monochrome versus colored”; the implementation decision is specifically based on the resolved SVG containing `currentColor`.
+
+## Processor Metadata
+
+`processor` receives the mutable generated style item and resolved metadata:
+
+```ts
+export default defineEngineConfig({
+  plugins: [icons()],
+  icons: {
+    processor(styleItem, meta) {
+      // meta.collection: resolved Iconify collection
+      // meta.name: resolved icon name
+      // meta.svg: loaded SVG source
+      // meta.source: 'custom' | 'local' | 'cdn'
+      // meta.mode: final 'mask' or 'bg' mode
+
+      if (meta.source === 'cdn')
+        styleItem.opacity = '0.95'
+    },
+  },
+})
+```
+
+The callback mutates `styleItem` in place before the shortcut result is returned.
+
+## Custom Collections and Reloading
+
+Custom collection values are opaque Iconify loader functions or inline SVG maps. PikaCSS cannot infer the backing file path of a loader, so editing a file used inside a custom loader does not automatically trigger config reload.
+
+When a custom collection reads external files, either:
+
+- Restart or touch the PikaCSS config after changes, or
+- Implement the loading in a PikaCSS plugin that calls `engine.addConfigDependency(path)` for each external file.
 
 ## Troubleshooting
 
-| Symptom | Fix |
-|---|---|
-| Icon not showing | Install the collection: `pnpm add -D @iconify-json/{collection}` |
-| Icon shows as empty box | Check the icon name — use `https://icon-sets.iconify.design` to verify |
-| Wrong color | Try `?mask` mode suffix to use `currentColor` |
-| Icon size wrong | Adjust `scale` in config or add `width`/`height` in pika() |
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Installed collection is ignored | Neutral entry used | Import from `@pikacss/plugin-icons/node` |
+| `autoInstall` has no effect | Neutral entry or disabled package installation | Use `/node` and verify the environment permits installs |
+| Icon not found locally | Collection package absent or wrong cwd | Install `@iconify-json/{collection}` and verify `icons.cwd` |
+| CDN icon does not load | No CDN configured, bad template, or transient request failure | Configure `icons.cdn`; a later resolution retries failures |
+| Icon has wrong color behavior | Rendering mode mismatch | Use `?mask`, `?bg`, or set `icons.mode` |
+| Icon size is unexpected | No explicit unit or scale | Set `unit`/`scale`, or add width and height in `pika()` |
+| Editor completion is too broad or missing concrete names | No explicit completion list | Add `icons.autocomplete` entries |


### PR DESCRIPTION
## Summary

Refresh the published `pikacss-use` consumer skill against the current PikaCSS implementation and documentation contract.

## Why

The skill had drifted behind several recent changes:

- setup examples omitted the direct `@pikacss/core` dependency and current Node/Vite compatibility constraints
- the official design-tokens plugin was missing entirely
- icons and design-tokens guidance did not reflect the neutral entry versus `/node` runtime-adapter split
- selector examples mixed built-in `$:pseudo` syntax with custom aliases
- CSS fallback examples did not use the current `[primary, fallback[]]` tuple
- build options omitted `cwd`, `currentPackageName`, replacement semantics for scan globs, and current codegen/config behavior
- plugin-authoring guidance did not cover hook context, structured diagnostics, `createEngine(..., { onDiagnostic })`, or `engine.addConfigDependency()`

## Changes

- rewrote the main `skills/pikacss-use/SKILL.md` routing and quick-start guidance
- aligned build integration, customization, icons, fonts, and plugin-development references with current source
- added a dedicated design-tokens reference covering inline/file sources, themes, aliases, pruning, diagnostics, watching, and runtime adapters
- updated the public Agent Skills docs and synchronized the zh-TW translation
- clarified unsupported source transforms, zero-config setup, and Nuxt-specific integration behavior

## Review notes

This PR changes documentation and the published skill only; no package runtime code is modified.

I performed a source-level review against the current `main` implementations for:

- unplugin option resolution and config discovery
- Nuxt module wiring
- public core types and selector/fallback behavior
- plugin lifecycle context and diagnostics
- icons and design-tokens Node adapters
- external config dependency watching
- fonts provider/config shapes

The review/fix loop also corrected fallback emission order, the raw `@import` contract for `appendCssImport()`, a type-safe icons processor example, Taiwan terminology, zero-config guidance, and the distinction between warning logs and structured diagnostics.

## Validation

CI is green on Node.js 22 and 24 across Ubuntu, macOS, and Windows. The check job passed build, codegen drift, documentation implementation contracts, publish correctness, Vite E2E, lint, typecheck, docs dead-link validation, zh-TW lint, and i18n freshness checks.

Local commands were not executed because this environment did not have a checked-out repository; GitHub Actions provided the authoritative repository validation.