### PR TITLE
feat(agents): add /review-pr and /maintenance-sweep (Phase 3 + 4)

### DIFF
--- a/.claude/skills/maintenance-sweep/SKILL.md
+++ b/.claude/skills/maintenance-sweep/SKILL.md
@@ -60,3 +60,5 @@ Runs locally under the owner's own credentials, so no repository secret is invol
 # weekly, Monday 09:00 — the machine must be awake
 0 9 * * 1 cd /path/to/pikacss && claude -p "/maintenance-sweep" >> /tmp/pikacss-sweep.log 2>&1
 ```
+
+Use a shell cron, not Claude Code's own scheduled tasks: `disable-model-invocation: true` above also stops a scheduled task from firing this skill as its prompt. Passing it as the prompt to `claude -p` counts as an owner invocation and works. Drop the flag only if you decide you want Claude to reach for this sweep on its own.

--- a/.claude/skills/maintenance-sweep/SKILL.md
+++ b/.claude/skills/maintenance-sweep/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: maintenance-sweep
+description: Find and fix accumulated maintenance drift — docs, translations, API reference gaps, browser data — and open one pull request per topic. Use when running the periodic maintenance pass, manually or on a schedule.
+disable-model-invocation: true
+allowed-tools: Bash(pnpm maintain-docs:analyze) Bash(pnpm maintain-i18n:status:*) Bash(pnpm maintain-docs:gen-api) Bash(pnpm update:browsers) Bash(gh pr list:*) Bash(gh pr create:*) Bash(git checkout:*) Bash(git switch:*) Bash(git add:*) Bash(git commit:*) Bash(git push:*) Bash(git diff:*) Bash(git status:*) Read Grep Glob Edit Write
+---
+
+# Maintenance sweep
+
+You are operating autonomously. The owner is not watching and cannot answer questions mid-run, so asking "shall I…?" blocks the work. Proceed on anything reversible that follows from the checks below; anything else becomes a note in the pull request body, not a question.
+
+## Hard limits
+
+- **Three pull requests per run, maximum.** Fewer is fine. Leaving work for the next run is fine; flooding the owner is not.
+- **One topic per pull request.** Never combine a translation sync with a docs rewrite.
+- **Never merge.** Opening the pull request is where you stop.
+- **Never touch dependency policy.** `pnpm update:browsers` is in scope; editing `pnpm-workspace.yaml`, adding dependencies, or relaxing `minimumReleaseAge`/`trustPolicy`/`overrides` is not.
+
+## Before starting
+
+```bash
+gh pr list --state open --json number,title,headRefName
+```
+
+Skip any topic that already has an open pull request. Re-opening the same drift every run is the failure mode that makes a scheduled sweep worthless.
+
+## Topics, in priority order
+
+Run each check, then act only on real findings.
+
+| Topic | Detect | Act |
+|---|---|---|
+| Docs drift | `pnpm maintain-docs:analyze` | Fix outdated or missing pages with the `maintain-docs` skill, then hand the result to `maintain-docs-review` before opening the pull request |
+| Translation staleness | `pnpm maintain-i18n:status` | Sync the stale pages with the `maintain-i18n` skill, including the `translation:` frontmatter via `--mark-synced` |
+| API reference gaps | `pnpm maintain-docs:gen-api` | If it reports JSDoc coverage gaps, fill them with the `maintain-jsdocs` skill until the run is clean. Commit the regenerated `docs/api/*.md` — never hand-edit them |
+| Browser data | `pnpm update:browsers` | Commit the lockfile and any regenerated `packages/core/src/generated/*` from `pnpm generate:core:css`. This one touches `pnpm-lock.yaml`, so it always needs the owner |
+
+`pnpm maintain-jsdocs:lint` is knowingly broken — it reports hundreds of false positives on legitimate long `@remarks` prose. Do not run it and do not act on it.
+
+## Per pull request
+
+Branch as `chore/maintenance-<topic>`, title as `chore(maintenance): <topic>`, and a body with four sections:
+
+- **What changed** and why the check flagged it.
+- **Evidence** — the commands you ran and their observed output. Only claims you can point at.
+- **Needs your decision** — anything you deliberately left alone.
+- **Risk** — what could break, or "none, generated output only".
+
+Then verify: the touched area's own validation (`pnpm lint`, the relevant `pnpm --filter <pkg> test`, `pnpm maintain-i18n:lint`) before pushing. A red pull request costs the owner more than a missing one.
+
+## Finishing
+
+End with a summary of every topic checked, what you opened, and what you deliberately deferred. If nothing drifted, say that plainly — a clean sweep with no pull requests is a successful run.
+
+## Scheduling
+
+Runs locally under the owner's own credentials, so no repository secret is involved:
+
+```bash
+# weekly, Monday 09:00 — the machine must be awake
+0 9 * * 1 cd /path/to/pikacss && claude -p "/maintenance-sweep" >> /tmp/pikacss-sweep.log 2>&1
+```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: review-pr
+description: Review a pull request with this repository's fresh-context reviewers and post one structured verdict comment. Use for any pull request before merging it, and especially for pull requests whose author has not read AGENTS.md.
+argument-hint: "[pr-number]"
+disable-model-invocation: true
+allowed-tools: Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr checkout:*) Bash(gh pr comment:*) Bash(git diff:*) Bash(git log:*) Bash(git status:*) Read Grep Glob
+---
+
+# Review pull request $ARGUMENTS
+
+CI has no LLM reviewer, so this is where the rules that cannot be scripted get checked. Your job is to produce one comment the owner can act on in under a minute, and nothing else.
+
+**You do not fix, push, or merge.** Findings go in the comment; the owner decides.
+
+## 1. Read before you run
+
+```bash
+gh pr view $ARGUMENTS --json title,author,baseRefName,headRefName,files,labels,body
+gh pr diff $ARGUMENTS
+```
+
+Assume the author has not read AGENTS.md. Read the whole diff before executing anything from the branch.
+
+**Do not run `pnpm install` if the pull request touches `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`.** Installing executes dependency lifecycle scripts from a manifest you did not write, and this repository's supply-chain policy (`minimumReleaseAge`, `trustPolicy: no-downgrade`, security `overrides`) is exactly what such a change could quietly relax. Review those hunks statically and put them under Owner decision.
+
+If the diff is otherwise clean and you need to run tests, `gh pr checkout $ARGUMENTS` first.
+
+## 2. Dispatch the reviewers that apply
+
+Run them in parallel, one message, based on what the diff touches:
+
+| Touched | Reviewer |
+|---|---|
+| `packages/*/src/**` | `engine-review` |
+| test files, coverage config | `maintain-tests-review` |
+| `docs/**`, any `README.md`, `docs/.examples/**` | `maintain-docs-review` |
+| `docs/zh-tw/**` | invoke the `maintain-i18n` skill yourself — there is no reviewer for it |
+
+Give each reviewer the PR number, the file list in its scope, and the base ref. They read the repository themselves; do not paste the diff into their prompt.
+
+Nothing in scope means say so and stop — do not invent a review.
+
+## 3. Check what no reviewer owns
+
+- CI status: `gh pr view $ARGUMENTS --json statusCheckRollup`. A red gate is the answer; do not re-derive it by hand.
+- Scope: does the diff do only what the title and body claim? Name the hunks that do not.
+- Supply chain: any new dependency, or any loosening of `pnpm-workspace.yaml` policy.
+- Public surface: `packages/*/package.json` `exports`, `engines`, `files`, and exported type shapes.
+
+## 4. Post exactly one comment
+
+```bash
+gh pr comment $ARGUMENTS --body "<your verdict>"
+```
+
+Structure it as:
+
+- **Verdict** — one line: ready to merge, ready with notes, or changes needed.
+- **Blocking** — each finding as `file:line — what is wrong — the fix`. Empty is fine; say so.
+- **Owner decision** — breaking changes, new dependencies, coverage exceptions, public-contract changes, anything the reviewers escalated. Empty is fine; say so.
+- **Checked** — which reviewers ran, which commands you ran, and what you did not check.
+
+Say plainly what you did not verify. A review that hides its gaps is worse than a short one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,8 @@ Correctness rules encoded by regression tests — do not "simplify" them away:
 - Unit or integration test creation, refinement, coverage work, or downstream validation: use the `maintain-tests` skill directly from the main agent, then hand completed work to `maintain-tests-review`.
 - Changes under `packages/*/src/**`, and any pull request from an outside contributor: hand the finished work to `engine-review`. It owns the engine invariants, the regression-test requirement, and public-surface/breaking-change classification.
 - Consumer installation, application configuration, troubleshooting, examples for using PikaCSS in a project, and authoring or modifying plugin implementation, hook usage, config augmentation, and plugin tests: use the `pikacss-use` domain skill directly from the main agent. It does not have a dedicated paired custom agent.
+- Reviewing an open pull request before the owner merges it: `/review-pr <number>`. It dispatches whichever reviewers the diff calls for and posts one verdict comment. It never fixes, pushes, or merges.
+- Periodic maintenance drift (docs, translations, API reference gaps, browser data): `/maintenance-sweep`. Runs autonomously, opens at most three pull requests per run, one topic each.
 
 ## Composition Rules
 


### PR DESCRIPTION
The third and fourth layers of agent-run maintenance. Both run locally under the owner's credentials, because the Anthropic key deliberately stays off the CI runner: CI holds only deterministic gates (#93), and these two carry everything that needs judgment.

## `/review-pr <number>`

The reviewer CI does not have. One command, one comment.

- Reads `gh pr view` and the full diff before executing anything from the branch, and assumes the author has not read AGENTS.md.
- Dispatches whichever of the three read-only reviewers the diff calls for, in parallel: `engine-review` for `packages/*/src/**`, `maintain-tests-review` for tests, `maintain-docs-review` for docs and READMEs. `docs/zh-tw/**` has no reviewer, so it invokes the `maintain-i18n` skill instead.
- Covers what no reviewer owns: scope creep against the PR's own claims, new dependencies, public surface (`exports`, `engines`, exported type shapes), and CI status.
- Posts exactly one comment: **Verdict / Blocking / Owner decision / Checked**, where "Checked" names what was *not* verified.
- Never fixes, pushes, or merges.

**Supply-chain rule worth calling out:** it refuses to run `pnpm install` when a pull request touches `package.json`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml`. Installing executes dependency lifecycle scripts from a manifest the reviewer did not write, and those files are exactly where `minimumReleaseAge`, `trustPolicy: no-downgrade`, and the security `overrides` live. Those hunks get reviewed statically and escalated.

## `/maintenance-sweep`

Closes the loop that previously required the owner to initiate every maintenance pass.

- Checks docs drift (`maintain-docs:analyze`), translation staleness (`maintain-i18n:status`), API reference gaps (`maintain-docs:gen-api`), and browser data (`update:browsers`).
- Hard limits: at most **three** pull requests per run, one topic each, never merge, never touch dependency policy beyond the browser-data refresh.
- Lists open pull requests first and skips topics already covered, so a weekly run does not re-open the same drift.
- Carries the autonomous-run framing so a scheduled invocation does not stall waiting for an answer, and explicitly does not run the known-broken `maintain-jsdocs:lint`.
- Every pull request body is fixed-shape: What changed / Evidence (commands actually run) / Needs your decision / Risk.
- The skill body documents the cron line. It runs locally, so the machine has to be awake; a missed week costs drift, not correctness.

## Validation

`pnpm lint` passes, `pnpm ci:pr-gates` passes, and `pnpm maintain-docs:gen-api` currently reports `✅ No JSDoc coverage gaps detected` — which is why the sweep's API-gap topic will normally be a no-op today.

Both skills are prose-only, so there is nothing here for the test suite to cover. The real test is the first run of each: `/review-pr` on the next outside pull request, and `/maintenance-sweep` once you decide the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)