### PR TITLE
refactor(agents): de-prescribe the JSDoc workflow and fix its linter

### DIFF
--- a/.claude/skills/maintain-jsdocs/SKILL.md
+++ b/.claude/skills/maintain-jsdocs/SKILL.md
@@ -1,247 +1,75 @@
 ---
 name: maintain-jsdocs
-description: 'Orchestrate PikaCSS codebase-wide JSDoc maintenance with a scaffold-and-fill workflow. Use when: (1) filling or improving JSDoc across all exported declarations, (2) running whole-repo or targeted JSDoc maintenance, (3) ensuring gen-api-docs produces zero coverage gaps. The workflow scaffolds JSDoc templates with @todo FILL markers via TypeScript AST on every exported declaration (including @internal), then the executing agent fills them iteratively.'
+description: 'Maintain JSDoc on exported declarations so the generated API reference has zero coverage gaps. Use when: (1) filling or improving JSDoc for exports, (2) running whole-repo or targeted JSDoc maintenance, (3) making gen-api-docs report zero gaps.'
 ---
 
 # Maintain JSDocs
 
-## Scope boundary
+## Scope
 
-- Authoritative workflow for JSDoc maintenance in PikaCSS.
-- JSDoc-only. README and docs edits are out of scope unless the user explicitly broadens the request.
-- Targets **all exported declarations** across all source files in each package, not just the public API surface from `index.ts`.
-- Includes `@internal` exports — the scaffold preserves existing `@internal` tags in generated templates so gen-api-docs skips them, but the JSDoc content is still maintained.
-- Also covers module augmentation members in plugin packages.
-- Keep all JSDoc content in English.
+- JSDoc only. README and docs pages are out of scope unless the request says otherwise.
+- Covers **all exported declarations** in every source file of a package, not just what `index.ts` re-exports, plus module augmentation members in plugin packages.
+- Includes `@internal` exports: gen-api skips them, but their JSDoc is still maintained.
+- Excludes `dist/`, `coverage/`, `*.test.ts`, `*.spec.ts`, `pika.gen.*`, `generated-*.ts`.
+- English only.
+
+Package directories in this repository: !`grep -o "dir: '[^']*'" "${CLAUDE_PROJECT_DIR}/scripts/_skill-shared/index.ts" | sed "s/dir: //;s/'//g" | tr '\n' ' '`
+
+Ask which packages to process when the request does not say; use `AskUserQuestion` if it is available.
+
+## The contract
+
+`gen-api-docs` extracts JSDoc from `packages/*/src/index.ts` via the TypeScript compiler API. Every gap renders as "Missing JSDoc summary." on a published page, so the gap list is the definition of done:
+
+| Export kind | Required |
+|---|---|
+| Function | Summary + `@param` description per parameter |
+| Interface | Summary + description per property |
+| Type alias | Summary |
+| Constant / Variable | Summary |
+| Class | Summary + description per public property and method, including constructor `@param`s |
+| Module augmentation member | Description per property |
+
+`collectCoverageGaps` in `scripts/maintain-docs/gen-api-docs.ts` is the authority. Read it when a gap report is surprising.
 
 ## Workflow
 
-```
-select packages → scaffold → fill loop → validate
-```
-
-| Step | What happens | Who |
-|------|-------------|-----|
-| **Select packages** | Multi-select packages to process via `vscode_askQuestions` | Executing agent + User |
-| **Scaffold** | TypeScript AST replaces all JSDoc with templates containing `@todo FILL:` markers | Runtime script |
-| **Fill loop** | Grep for `@todo FILL`, read each file, fill JSDoc content, remove markers | Executing agent (LLM) |
-| **Validate** | Run JSDoc lint for corruption check + gen-api-docs for zero-gap check + package typecheck | Executing agent |
-
-The scaffold script handles all the mechanical work (stripping old JSDoc, inserting templates with the right structure and tags). The LLM focuses purely on writing semantic content by filling in the `@todo FILL:` placeholders.
-
-## Runtime surface
-
-Entrypoint: `pnpm maintain-jsdocs:scaffold --packages <name>...`
-
-| Command | Purpose |
-|---------|---------|
-| `pnpm maintain-jsdocs:scaffold --packages <name>...` | Replace/insert JSDoc templates with `@todo FILL:` markers on all exported declarations (including `@internal`) |
-| `pnpm maintain-jsdocs:lint [--packages <name>...]` | Detect LLM fill-step corruption: literal `\n`/`\t`, collapsed lines, unfilled `@todo`, merged tags |
-
-Validation: `pnpm maintain-docs:gen-api` + `pnpm maintain-jsdocs:lint`
-
-## Exclusions
-
-- `dist/`, `coverage/`, generated outputs
-- `*.test.ts`, `*.spec.ts`
-- `pika.gen.ts`, `pika.gen.css`
-- `generated-*.ts`
-
-## Execution guide
-
-### Step 0: Select packages
-
-Use `vscode_askQuestions` to present a multi-select list of packages:
-
-```
-header: "JSDoc scope"
-question: "Which packages should be scaffolded for JSDoc maintenance?"
-multiSelect: true
-options:
-  - label: "@pikacss/core"
-  - label: "@pikacss/integration"
-  - label: "@pikacss/unplugin-pikacss"
-  - label: "@pikacss/nuxt-pikacss"
-  - label: "@pikacss/plugin-reset"
-  - label: "@pikacss/plugin-icons"
-  - label: "@pikacss/plugin-fonts"
-  - label: "@pikacss/plugin-typography"
-  - label: "@pikacss/eslint-config"
-```
-
-Map the user's selections to package directory names (e.g. `@pikacss/core` → `core`, `@pikacss/unplugin-pikacss` → `unplugin`).
-
-### Step 1: Scaffold
+1. **Find the gaps.** `pnpm maintain-docs:gen-api` lists every coverage gap by package and symbol. Work from that list.
+2. **Write the JSDoc** directly in the source file, reading the implementation and its call sites first.
+3. **Validate**:
 
 ```bash
-pnpm maintain-jsdocs:scaffold --packages core integration
+pnpm maintain-jsdocs:lint --packages <name>...   # corruption check
+pnpm maintain-docs:gen-api                       # zero-gap check
+pnpm --filter @pikacss/<name> typecheck
 ```
 
-The scaffold script:
-1. Uses the TypeScript compiler API to walk **all source files** in each package's `src/` directory (not just the `index.ts` entry point).
-2. Finds every exported declaration (functions, interfaces, types, constants, classes) and module augmentation members.
-3. For each symbol, generates a JSDoc template with `@todo FILL:` markers appropriate to its kind (function params, interface members, class public properties/methods/constructors, optional property defaults, type params, remarks, examples, etc.).
-4. Preserves existing `@internal` tags — symbols that were `@internal` get `@internal` in their generated template.
-5. **Aggressively replaces** any existing JSDoc with the template — this is a clean-restart strategy.
-6. Inserts templates where no JSDoc exists.
-7. Reports: files modified, total `@todo` markers inserted.
+Repeat until gen-api reports `✅ No JSDoc coverage gaps detected.`
 
-#### Template examples
+For large scopes, process one package per subagent in parallel rather than sweeping serially.
 
-Function:
-```ts
-/**
- * @todo FILL: describe createEngine
- *
- * @param config - @todo FILL: describe config
- * @returns @todo FILL: return value
- */
-```
+### Full restart (opt in, destructive)
 
-Interface member (optional property):
-```ts
-  /**
-   * @todo FILL: describe plugins
-   *
-   * @default @todo FILL: default
-   */
-  plugins?: EnginePlugin[]
-```
+`pnpm maintain-jsdocs:scaffold --packages <name>...` **replaces** existing JSDoc on every exported declaration with `@todo FILL:` templates, then you fill each marker and remove the tag.
 
-### Step 2: Fill loop
+Use it only when the existing JSDoc for a package is being rewritten wholesale on purpose. It discards good prose along with bad, so gap-driven editing is the default.
 
-Process files **one at a time** until no `@todo FILL` markers remain:
+## Quality bar
 
-1. **Search**: Use grep to find files containing `@todo FILL` in the target packages' `src/` directories.
-   ```
-   grep -rn "@todo FILL" packages/{core,integration}/src/
-   ```
-2. **Process**: For each file with markers:
-   - Read the full file.
-   - For every `@todo FILL: <hint>` marker, read the surrounding code to understand the symbol's purpose, implementation, type relationships, and usage patterns.
-   - Replace each `@todo FILL: <hint>` with complete JSDoc content following the [Quality guide](#quality-guide).
-   - Remove the `@todo` tag entirely — the filled content stays, the tag goes.
-   - Write the file back.
-3. **Repeat**: Search again. Continue until zero `@todo FILL` matches remain.
+Beyond zero-gap: every sentence must add something the type signature does not already say. "Returns the resolved engine configuration after plugin normalization" over "Returns a ResolvedEngineConfig".
 
-#### Fill rules
+Repo-specific conventions the generator and readers rely on:
 
-- When filling a `@todo FILL: describe <name>` that serves as the JSDoc summary, write the summary text directly (no tag prefix needed — it becomes the first line of the JSDoc block).
-- When filling `@param <name> - @todo FILL: describe <name>`, replace only the `@todo FILL: describe <name>` portion with the actual parameter description.
-- When filling `@returns @todo FILL: return value`, replace `@todo FILL: return value` with the actual return description.
-- When filling `@default @todo FILL: default`, replace `@todo FILL: default` with the actual default value.
-- Add `@remarks`, `@example`, `@typeParam` tags as needed — the template provides the minimum structure, the LLM can enrich beyond it.
+- `@default` on every optional interface property — the effective value or behavior when omitted, literals in inline code.
+- `@example` with a fenced `ts` block when usage is ordering-sensitive, composable, or easy to misuse.
+- `@remarks` for lifecycle, hook interaction, and cross-package relationships — this is where PikaCSS's non-obvious behavior belongs.
+- Each JSDoc tag starts its own real line. Never emit literal `\n` or `\t` inside a comment; `maintain-jsdocs:lint` fails on both.
 
-#### Fill anti-patterns
-
-**Never** produce replacements that contain literal `\n`, `\t`, or `\r` strings inside JSDoc. Each JSDoc tag and line must be a real line in the file, properly prefixed with ` * `. When adding multi-line content (e.g. `@remarks` followed by `@example`), write each section on its own line — do not collapse them into a single line with escape characters.
-
-### Step 3: Validate
-
-```bash
-# Lint JSDoc for LLM fill-step corruption — goal is "✅ No JSDoc lint issues detected."
-pnpm maintain-jsdocs:lint --packages <package>...
-
-# Check JSDoc coverage — goal is "✅ No JSDoc coverage gaps detected."
-pnpm maintain-docs:gen-api
-
-# Package-scoped typecheck for each touched package
-pnpm --filter @pikacss/<package> typecheck
-```
-
-If the lint reports issues (literal escape sequences, collapsed lines, unfilled todos, merged tags), fix them before proceeding to gen-api-docs.
-
-If gen-api-docs reports remaining gaps, return to Step 2 for those specific symbols.
-
-After both lint and gen-api-docs pass, produce a summary report for the user: packages processed, files modified, quality observations.
-
-## Quality guide {#quality-guide}
-
-gen-api-docs uses the TypeScript compiler API to extract JSDoc from `packages/*/src/index.ts` entry points. Every coverage gap means the generated API reference page shows "Missing JSDoc summary." to readers.
-
-### Zero-gap requirements
-
-Every non-`@internal` export must satisfy:
-
-| Export kind | Required |
-|-------------|----------|
-| Function | Summary + `@param` with description for each parameter |
-| Interface | Summary + description for every property member |
-| Type alias | Summary |
-| Constant / Variable | Summary |
-| Class | Summary + description for every public property and method (including parameters) |
-| Module augmentation member | Description for each property |
-
-### High-density JSDoc standard
-
-Beyond zero-gap, every JSDoc block should be semantically rich:
-
-- **`@param`** — Explain what the parameter controls, not just its type. Include constraints, defaults when omitted, and impact on behavior.
-- **`@returns`** — What the return value represents and any guarantees about its state.
-- **`@typeParam`** — For generic parameters: what they represent and important constraints.
-- **`@remarks`** — Usage context, lifecycle notes, cross-module relationships, performance considerations.
-- **`@example`** — Required when usage is non-obvious, ordering-sensitive, composable, or easy to misuse. Use fenced TypeScript code blocks.
-- **`@default`** — For optional interface properties: the effective default value or behavior when omitted. Use inline code for literal values.
-- **Class members** — Public properties need summary descriptions. Public methods follow the same `@param`/`@returns`/`@remarks` standard as top-level functions. Constructors need `@param` descriptions.
-
-### Writing principles
-
-- **Explain intent, not syntax.** "Returns the resolved engine configuration after plugin normalization" beats "Returns a ResolvedEngineConfig object".
-- **Be concrete.** Cover: purpose, when to use, constraints, defaults, side effects, edge cases.
-- **No filler.** Every sentence must add information beyond what the type signature already conveys. Avoid "Defines the X" or "Represents a Y" without semantic follow-up.
-- **Options interfaces**: document every field's purpose, default behavior, and impact on the system.
-- **Factory functions** (`create*`, `define*`): explain what gets created, prerequisites, and how to use the result.
-- **Plugin variables**: describe what the plugin does, which hooks it uses, and visible engine side effects.
-- **Type aliases**: explain the semantic meaning and when a consumer encounters or produces this type.
-- **Utility types**: explain the type-level transformation and provide a concrete usage example.
-
-### JSDoc format conventions
-
-Write standard JSDoc with `/**` and `*/` delimiters. Ensure proper indentation matching the surrounding code.
-
-**Function example:**
-```ts
-/**
- * Creates a new engine instance with the given configuration.
- *
- * Initializes the plugin pipeline, resolves layer ordering, and prepares
- * the atomic style registry. Call this once per application context.
- *
- * @param config - Engine configuration including plugins, layers, and preflight settings. When omitted, creates a minimal engine with no plugins.
- * @returns A fully initialized Engine ready to process style definitions.
- *
- * @example
- * ```ts
- * const engine = createEngine({ plugins: [resetPlugin()] })
- * ```
- */
-```
-
-**Interface example:**
-```ts
-/**
- * Configuration options for the PikaCSS engine.
- *
- * Controls plugin registration, layer ordering, selector defaults,
- * and preflight behavior for the atomic CSS generation pipeline.
- */
-export interface EngineConfig {
-  /**
-   * Plugins to register with the engine, processed in order.
-   *
-   * @default []
-   */
-  plugins?: EnginePlugin[]
-}
-```
-
-**Module augmentation member example:**
 ```ts
 declare module '@pikacss/core' {
   interface EngineConfig {
     /**
-     * CSS reset style to apply as a preflight.
-     * Controls which reset stylesheet is injected before utility styles.
+     * CSS reset style injected as a preflight, before utility styles.
      *
      * @default 'tailwind-preflight'
      */
@@ -252,10 +80,4 @@ declare module '@pikacss/core' {
 
 ## References
 
-- **[Quality Standards](references/workflow-rules.md)** — Detailed JSDoc format conventions, gen-api-docs alignment rules, and quality checklist.
-- **gen-api-docs source**: `scripts/maintain-docs/gen-api-docs.ts` — the authoritative consumer of JSDoc. Read its `collectCoverageGaps` function to understand exactly what gets flagged.
-
-## Agent pairing
-
-- The main agent or the `maintain-jsdocs` implementation agent can execute this workflow directly.
-- For large scopes (>5 packages), prefer delegating to the `maintain-jsdocs` agent to keep the main conversation focused.
+- [workflow-rules.md](references/workflow-rules.md) — format conventions and the quality checklist.

--- a/.claude/skills/maintain-tests/SKILL.md
+++ b/.claude/skills/maintain-tests/SKILL.md
@@ -17,7 +17,7 @@ description: 'Orchestrate PikaCSS unit and integration test maintenance for pack
 - Source files, behaviors, or risk areas to cover.
 - `full audit` or `focused update`.
 - Any known exception candidates or constraints.
-- Prefer `vscode_askQuestions` for clarification when available; otherwise ask in chat.
+- Ask when any of the above is unclear; use `AskUserQuestion` if it is available.
 
 ## Execution surface
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
       - name: check documentation implementation contracts
         run: pnpm maintain-docs:check-contracts
 
+      # Corruption check only: literal escape sequences, leftover @todo FILL
+      # markers, and merged tags. Coverage gaps are caught by the codegen-drift
+      # step above, which regenerates docs/api/*.md.
+      - name: check JSDoc integrity
+        run: pnpm maintain-jsdocs:lint
+
       - name: check publish correctness (publint + are-the-types-wrong)
         run: pnpm publint && pnpm attw
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,8 +188,8 @@ Correctness rules encoded by regression tests — do not "simplify" them away:
 
 ## Composition Rules
 
-- Choose one primary skill or workflow for a request.
-- Add a secondary skill only when the task genuinely spans two domains.
+- Choose one primary skill or workflow for a request, and add others when the task genuinely spans their domains.
+- Delegate independent subtasks to subagents and keep working while they run — one package per subagent for a sweep, one reviewer per touched area. Intervene when a subagent goes off track or lacks context.
 - Use the single `pikacss-use` skill for both consuming and authoring plugins.
 - Treat every maintenance skill as a main-agent execution skill. The only subagents are read-only reviewers.
 - `maintain-docs` (English) and `maintain-i18n` (zh-TW) compose: docs edits flow English-first, then i18n sync.

--- a/scripts/maintain-jsdocs/lint.ts
+++ b/scripts/maintain-jsdocs/lint.ts
@@ -77,54 +77,6 @@ function checkLiteralEscapes(lines: string[], filePath: string): LintIssue[] {
 }
 
 /**
- * Detects JSDoc comment lines that are excessively long (>300 chars),
- * which typically indicates that multi-line JSDoc was collapsed into a
- * single line during LLM replacement.
- *
- * Skips lines inside fenced code blocks.
- */
-function checkCollapsedLines(lines: string[], filePath: string): LintIssue[] {
-	const issues: LintIssue[] = []
-	const MAX_LENGTH = 300
-	let inJSDoc = false
-	let inCodeFence = false
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i]!
-		const stripped = line.trim()
-
-		if (stripped.startsWith('/**')) {
-			inJSDoc = true
-			inCodeFence = false
-		}
-
-		if (inJSDoc) {
-			if (stripped === '* ```ts' || stripped === '* ```typescript' || stripped === '* ```js' || stripped === '* ```') {
-				inCodeFence = !inCodeFence
-			}
-
-			if (!inCodeFence && stripped.startsWith('*') && line.length > MAX_LENGTH) {
-				issues.push({
-					file: filePath,
-					line: i + 1,
-					rule: 'no-collapsed-jsdoc',
-					message: `JSDoc line is ${line.length} chars (max ${MAX_LENGTH}). Likely collapsed from multiple lines.`,
-					excerpt: `${line.trimEnd()
-						.slice(0, 120)}...`,
-				})
-			}
-		}
-
-		if (inJSDoc && stripped.endsWith('*/')) {
-			inJSDoc = false
-			inCodeFence = false
-		}
-	}
-
-	return issues
-}
-
-/**
  * Detects leftover @todo FILL markers that were not replaced during the
  * fill step.
  */
@@ -211,7 +163,6 @@ function checkMultipleTagsOnOneLine(lines: string[], filePath: string): LintIssu
 
 const ALL_CHECKS = [
 	checkLiteralEscapes,
-	checkCollapsedLines,
 	checkUnfilledTodos,
 	checkMultipleTagsOnOneLine,
 ]
@@ -228,7 +179,6 @@ export async function runLint(args = process.argv.slice(2)) {
 			'',
 			'Rules:',
 			'  no-literal-escapes   Literal \\n/\\t/\\r in JSDoc (should be real newlines)',
-			'  no-collapsed-jsdoc   JSDoc line >300 chars (likely collapsed multi-line)',
 			'  no-unfilled-todo     Leftover @todo FILL markers',
 			'  no-merged-tags       Multiple @-tags on a single line',
 			'',


### PR DESCRIPTION
Closes the gate that #93 had to defer, and does the first pass of skill de-prescription.

## The linter was measuring the wrong thing

`pnpm maintain-jsdocs:lint` reported **351** failures on sources nobody had touched. All of them were `no-collapsed-jsdoc`, a rule that fails any JSDoc line over 300 characters on the theory that it was "likely collapsed from multiple lines".

The two failure modes it was proxying for already have precise rules:

- `no-literal-escapes` — literal `\n`/`\t`/`\r` inside a comment
- `no-merged-tags` — several `@tags` on one line

So the length heuristic detected nothing the other rules missed, and what it actually flagged was legitimate long-form `@remarks` prose. Removed.

| | Before | After |
|---|---|---|
| `pnpm maintain-jsdocs:lint` | 351 failures, exit 1 | `✅ No JSDoc lint issues detected.`, exit 0 |

With the linter honest again, it joins CI as a blocking step — the gate the plan called for and #93 could not include.

## The skill was written for a weaker model

261 lines → 83.

- **Gap-driven editing is now the default.** `maintain-jsdocs:scaffold` replaces the JSDoc on every exported declaration with `@todo FILL:` templates, discarding good prose along with bad. That is now an explicitly destructive opt-in for a deliberate wholesale rewrite, not step one of the normal flow.
- **The hardcoded package list had already drifted** — it listed nine packages and was missing `plugin-design-tokens`. It is now injected from the `PACKAGES` registry when the skill loads, so it cannot drift again. Verified: all ten resolve.
- **Dropped** the generic writing-principles bullets and two of the three long examples. **Kept** the zero-gap contract table, the repo-specific tag conventions (`@default` on optional properties, `@remarks` for hook and lifecycle behavior), and the pointer to `collectCoverageGaps` as the authority on what counts as a gap.
- **`vscode_askQuestions` is gone**, here and in `maintain-tests`. That tool does not exist in this harness; `AskUserQuestion` does. I reported this as fixed during Phase 1 — it was not, and this is the actual fix.

## AGENTS.md

The Composition Rules said "choose one primary skill; add a secondary only when the task spans two domains". That was a throttle for models that handled parallelism badly. Replaced with delegation guidance: one package per subagent for a sweep, one reviewer per touched area, intervene when a subagent goes off track.

## Validation

| Check | Result |
|---|---|
`pnpm maintain-jsdocs:lint` | exit 0, no issues |
`pnpm lint` | exit 0 |
`pnpm maintain-docs:gen-api` | no coverage gaps, and no working-tree drift afterwards |
Dynamic package list | resolves all 10 registry entries, `plugin-design-tokens` included |

## Not done

The consumer-facing `skills/pikacss-use/SKILL.md` is 365 lines and is the largest skill in the repo. It affects every downstream user, so it deserves the same pass — but it is a public contract and worth doing on its own, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)