### PR TITLE
chore(agents): owner-facing PR template and reviewer memory (Phase 5)

### DIFF
--- a/.claude/agent-memory/README.md
+++ b/.claude/agent-memory/README.md
@@ -1,0 +1,16 @@
+# Reviewer memory
+
+The three reviewers in `.claude/agents/` declare `memory: project`, so each writes
+its accumulated lessons to `.claude/agent-memory/<agent-name>/`.
+
+This directory is committed on purpose. A reviewer that learns "this repository
+keeps forgetting X" is only useful if the next session, and the next machine,
+starts with that knowledge. Machine-local notes belong in
+`.claude/agent-memory-local/`, which is gitignored.
+
+Treat the contents as reviewer notes, not as rules:
+
+- Rules that must always apply belong in `AGENTS.md`.
+- Rules that must be enforced belong in `.claude/settings.json`, `.github/CODEOWNERS`,
+  or a CI gate. Memory is context, never enforcement.
+- A note that turns out to be wrong should be deleted rather than argued with.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+<!--
+Four sections, kept short. The point is that the reviewer and the repository
+owner can decide in under a minute. Delete a section only if it is genuinely
+empty, and say so rather than removing the heading silently.
+-->
+
+## What changed
+
+<!-- One or two sentences. What behavior or content is different now, and why. -->
+
+## Evidence
+
+<!--
+Commands actually run and what they printed. Claims without evidence belong in
+"Needs a decision", not here. CI results count; "should work" does not.
+-->
+
+## Needs a decision
+
+<!--
+Anything the owner must settle: breaking changes, new dependencies, public API
+additions, coverage exceptions, deliberate omissions. Write "nothing" if there
+is nothing.
+-->
+
+## Risk
+
+<!-- What could break, and what is not covered by tests or CI. -->


### PR DESCRIPTION
## What changed

Two small pieces of the supervision interface.

`.github/pull_request_template.md` fixes the shape of every pull request: **What changed / Evidence / Needs a decision / Risk**. "Evidence" means commands actually run and what they printed — not "should work". This also drags an outside contributor's pull request into a reviewable shape without that contributor having read AGENTS.md, which is the point: the template lives on the base branch, so it applies to anyone opening a pull request through the web UI.

`.claude/agent-memory/` gets a README and is committed on purpose. The three reviewers declare `memory: project`, so they write there. A reviewer that learns "this repository keeps forgetting X" is only useful if the next session, on any machine, starts with that knowledge. The README states the boundary: memory is context, never enforcement — enforcement stays in `.claude/settings.json`, `.github/CODEOWNERS`, and CI gates. `.claude/agent-memory-local/` remains gitignored for machine-local notes.

## Evidence

`pnpm lint` exits 0. Both files are documentation, so there is nothing executable to test. The template's real verification is the next pull request opened through the web UI; `gh pr create --body` bypasses templates, so agent-opened pull requests must follow the shape deliberately, which is now what the reviewers check for.

## Needs a decision

Nothing.

## Risk

None. Neither file affects the build, the published packages, or CI behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)