### PR TITLE
ci: bring the published consumer skill under contract checks

### DIFF
--- a/scripts/maintain-docs/check-contracts.ts
+++ b/scripts/maintain-docs/check-contracts.ts
@@ -8,6 +8,7 @@ interface PackageManifest {
 	private?: boolean
 	engines?: Record<string, string>
 	exports?: Record<string, unknown>
+	peerDependencies?: Record<string, string>
 }
 
 const UNPLUGIN_SOURCE_PATH = 'packages/unplugin/src/index.ts'
@@ -139,11 +140,26 @@ if (distinctNodeRanges.size > 1) {
 
 const unpluginManifest = manifests.get('@pikacss/unplugin-pikacss')
 const documentedNodeRange = unpluginManifest?.engines?.node
+// The published consumer skill is installed into arbitrary agents via
+// `npx skills add`, so a stale version claim there misleads users we never see.
+// Nothing checked it until now.
+const CONSUMER_SKILL_PATH = 'skills/pikacss-use/SKILL.md'
+
+const vitePeerRange = unpluginManifest?.peerDependencies?.vite
+if (vitePeerRange != null) {
+	expectContains(
+		CONSUMER_SKILL_PATH,
+		vitePeerRange,
+		'state the supported Vite range from the unplugin peerDependencies',
+	)
+}
+
 if (documentedNodeRange != null) {
 	for (const path of [
 		'docs/getting-started/setup.md',
 		'docs/zh-tw/getting-started/setup.md',
 		'packages/unplugin/README.md',
+		CONSUMER_SKILL_PATH,
 	]) {
 		expectContains(path, `\`${documentedNodeRange}\``, `document the supported Node.js range from the published packages`)
 	}
@@ -154,11 +170,13 @@ const unpluginExports = Object.keys(unpluginManifest?.exports ?? {})
 
 for (const subpath of unpluginExports) {
 	const specifier = `@pikacss/unplugin-pikacss${subpath.slice(1)}`
-	expectContains(
-		'packages/unplugin/README.md',
-		specifier,
-		`list the exported bundler entry point ${specifier}`,
-	)
+	for (const path of ['packages/unplugin/README.md', CONSUMER_SKILL_PATH]) {
+		expectContains(
+			path,
+			specifier,
+			`list the exported bundler entry point ${specifier}`,
+		)
+	}
 }
 
 const unpluginSource = readWorkspaceFile(UNPLUGIN_SOURCE_PATH)

--- a/skills/pikacss-use/SKILL.md
+++ b/skills/pikacss-use/SKILL.md
@@ -28,7 +28,7 @@ Load the smallest relevant reference instead of guessing from memory:
 
 ## Non-Negotiable Facts
 
-- PikaCSS packages require **Node.js 22 or later**.
+- Node-targeted PikaCSS packages declare `engines.node` as `>=22`. The platform-neutral packages (`@pikacss/core`, `@pikacss/plugin-icons`, `@pikacss/plugin-design-tokens`) declare none on purpose.
 - The Vite adapter supports **Vite 7 and 8** (`^7.0.0 || ^8.0.0`).
 - `pika` and `pikap` are generated compile-time globals. **Never import them.**
 - Arguments must be statically analyzable. Runtime values belong in CSS variables, variant maps, or predefined shortcuts.


### PR DESCRIPTION
## What changed

`skills/pikacss-use/SKILL.md` is installed into arbitrary agents through `npx skills add pikacss/pikacss`. A stale version claim there misleads users this repository never sees, and nothing was checking it — `check-contracts` covered the docs pages and the unplugin README, but not the skill.

It now asserts, against the manifests rather than against prose:

- the Node range from `engines.node`
- the Vite range from the unplugin `peerDependencies`
- every exported bundler entry point

One wording change in the skill: the Node requirement was written as "Node.js 22 or later", which no check can match. It now names the literal `>=22` and the three platform-neutral packages (`core`, `plugin-icons`, `plugin-design-tokens`) that deliberately declare no `engines` field — a distinction the skill previously blurred.

## Evidence

I read the skill against source before changing anything. Everything checkable was already accurate:

| Claim | Source | Verdict |
|---|---|---|
| Vite `^7.0.0 \|\| ^8.0.0` | `packages/unplugin/package.json` peerDependencies | matches |
| six bundler entry points | unplugin `exports` | all six present |
| `autoCreateConfig` default `false` | `packages/unplugin/src/index.ts:70` | matches |
| `defaultSelector: '.%'`, `prefix: 'pk-'` | core | matches |
| Node `>=22` | manifests | correct, but stated as prose |

Then:

- `pnpm maintain-docs:check-contracts` → `Documentation contracts OK (7 Node-targeted package engines, 3 neutral packages, 6 bundler entry points, and 7 scan patterns checked)`
- Negative test: rewrote the skill's Vite range to `^6.0.0` → the check failed with `skills/pikacss-use/SKILL.md: state the supported Vite range from the unplugin peerDependencies (missing "^7.0.0 || ^8.0.0")`. Restored, green again.
- `pnpm lint` → exit 0

## Needs a decision

**The plan said to de-prescribe this skill; I am not doing it, and want that on the record.** That item was based on its line count (365, the largest in the repo), not on its content. Having now read it, it is a dense fact sheet with progressive disclosure into eight references — version constraints, generated filenames, config discovery order, the CSS fallback tuple shape, the `$`-prefix selector convention, `__shortcut`/`__layer`/`__important`, the `/node` adapter rules, and a troubleshooting table. Very little of it is advice a model already has.

More importantly, the de-prescription argument comes from guidance about *strong* models, and this is the one skill that does not run on one: it runs in whatever agent a consumer installed it into. Trimming it optimizes for Opus 5 at the expense of everyone else's tooling.

If you still want it shortened, say so and I will, but I would be doing it against my own read of the evidence.

## Risk

Low. The three new assertions are string containment against values read from the manifests; a bump to the Vite peer range or a new bundler entry point will now fail CI until the skill is updated, which is the intent. No published code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)