### PR TITLE
fix(unplugin): stop stale modules surviving an engine re-derivation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@ Correctness rules encoded by regression tests — do not "simplify" them away:
 - The atomic style ID placeholder `%` is not treated as a placeholder when directly preceded by a digit (`@supports (width: 50%)`), and selector normalization never rewrites quoted content.
 - `AbstractResolver` rule mutations (add/remove) clear the whole resolution cache; recursively expanded results may depend on any rule.
 - During one `renderPreflights` pass each preflight function runs exactly once (`engine.invokePreflight` memoization); the variables pruning preflight reuses those results.
-- Plugins that load external files must register them via `engine.addConfigDependency(path)` so the unplugin reloads on change (used by `plugin-design-tokens`).
+- Plugins that load external files must register them via `engine.addConfigDependency(path)` so the unplugin reloads on change (used by `plugin-design-tokens`). Registration alone is not enough: the unplugin reloads only when the file's *content* changed, so a dependency whose bytes stay identical while its meaning shifts (env vars, the clock, an unregistered neighbour file) will not be picked up.
 
 ## Maintenance Playbook
 

--- a/docs/integrations/ssr-and-production.md
+++ b/docs/integrations/ssr-and-production.md
@@ -42,10 +42,14 @@ The result passes through your bundler's normal CSS pipeline (minification, hash
 
 The dev server re-creates the engine (and regenerates both output files) when:
 
-- **The config file changes.** The resolved `pika.config.*` file is watched; a content change reloads the config and rebuilds the engine.
-- **A config dependency changes.** Plugins that load external files register them via `engine.addConfigDependency(path)` — for example, [@pikacss/plugin-design-tokens](/official-plugins/design-tokens) registers its token source files. Those paths are watched the same way as the config file.
+- **The config file changes.** The resolved `pika.config.*` file is watched. Only a *content* change counts — saving without editing anything, or a change that leaves the bytes identical, is ignored.
+- **A config dependency changes.** Plugins that load external files register them via `engine.addConfigDependency(path)` — for example, [@pikacss/plugin-design-tokens](/official-plugins/design-tokens) registers its token source files. Those paths are watched the same way as the config file, content comparison included.
 
 Both paths rely on the bundler's file watcher (esbuild is the exception — it has no watch-based reload path). Ordinary source edits do not re-create the engine; they only add or update the affected file's usages, and the generated files are rewritten only when the resolved styles actually changed.
+
+**Re-creating the engine triggers a full page reload, not an HMR update** (Vite). Atomic class names are assigned in discovery order, so a fresh engine can hand the same name to a different declaration. Anything the browser still holds from the previous generation would then point at the wrong rule — silently, with no error — so the page is reloaded to keep the served modules and the regenerated CSS in the same generation. Expect to lose page state (form input, router position) when you edit your config.
+
+A config file that fails to evaluate is the exception: the dev server keeps the last-good engine, so nothing is reassigned and the page is left alone. Fix the file and save again to pick it up.
 
 ## Type-Level Performance
 

--- a/docs/plugin-development/create-a-plugin.md
+++ b/docs/plugin-development/create-a-plugin.md
@@ -71,7 +71,7 @@ defineEnginePlugin({
 })
 ```
 
-The build integrations watch these paths and re-create the engine when one changes (see [SSR & Production](/integrations/ssr-and-production#what-triggers-a-reload-in-dev)). Without this, users must restart the dev server to pick up edits to your plugin's source files. This is how `@pikacss/plugin-design-tokens` reloads token files.
+The build integrations watch these paths and re-create the engine when one changes — specifically when its *content* changes, so a dependency whose bytes stay the same is treated as unchanged even if its meaning did not (see [SSR & Production](/integrations/ssr-and-production#what-triggers-a-reload-in-dev)). Without this, users must restart the dev server to pick up edits to your plugin's source files. This is how `@pikacss/plugin-design-tokens` reloads token files.
 
 ## Testing a Plugin
 

--- a/docs/zh-tw/integrations/ssr-and-production.md
+++ b/docs/zh-tw/integrations/ssr-and-production.md
@@ -13,8 +13,8 @@ category: integrations
 order: 24
 translation:
   sourceFile: docs/integrations/ssr-and-production.md
-  sourceCommit: 36ab046b5f27060274a79d160c9b43606652d780
-  sourceBlob: 5df849173e8baab909992f60f22de00abc1d63d7
+  sourceCommit: 16dc72d27d06160bfb9a659139220b4c08545482
+  sourceBlob: eb77c00d51122d65c8ab3acee8dee67ebe7f772e
 ---
 
 # SSR 與正式環境 {#ssr-production}
@@ -46,10 +46,14 @@ PikaCSS 的輸出是一個在建置時期產生的靜態 CSS 檔案。光是這�
 
 開發伺服器會在以下情況重新建立引擎（並重新產生兩個輸出檔案）：
 
-- **設定檔變更時。** PikaCSS 會監看解析後的 `pika.config.*` 檔案；內容一有變更，就會重新載入設定並重建引擎。
-- **設定相依（config dependency）變更時。** 會載入外部檔案的外掛，會透過 `engine.addConfigDependency(path)` 註冊這些檔案，例如 [@pikacss/plugin-design-tokens](/zh-tw/official-plugins/design-tokens) 會註冊它的 token 來源檔案。這些路徑的監看方式和設定檔相同。
+- **設定檔變更時。** PikaCSS 會監看解析後的 `pika.config.*` 檔案。只有*內容*變更才算——沒有實際編輯就存檔，或是變更後位元組完全相同，都會被忽略。
+- **設定相依（config dependency）變更時。** 會載入外部檔案的外掛，會透過 `engine.addConfigDependency(path)` 註冊這些檔案，例如 [@pikacss/plugin-design-tokens](/zh-tw/official-plugins/design-tokens) 會註冊它的 token 來源檔案。這些路徑的監看方式和設定檔相同，包含內容比對在內。
 
 這兩條路徑都仰賴打包工具的檔案監看器（esbuild 是例外，它沒有以監看為基礎的重新載入路徑）。一般的原始碼編輯不會重新建立引擎，只會新增或更新受影響檔案的使用情形，而產生出來的檔案只有在解析後的樣式真的變更時才會重新寫出。
+
+**重新建立引擎會觸發整頁重新載入，而不是 HMR 更新**（Vite）。原子 class 名稱是依照被發現的順序指派的，所以全新的引擎可能把同一個名稱交給不同的宣告。此時瀏覽器手上任何屬於前一代的內容都會指向錯誤的規則——而且是無聲無息、不會有任何錯誤——因此 PikaCSS 會重新載入頁面，確保供應出去的模組與重新產生的 CSS 屬於同一代。編輯設定時請預期頁面狀態（表單輸入、路由位置）會遺失。
+
+設定檔無法成功執行時是例外：開發伺服器會保留上一份正常運作的引擎，因此不會有任何名稱被重新指派，頁面也不會被動到。修好檔案再存檔一次即可套用。
 
 ## 型別層級的效能 {#type-level-performance}
 

--- a/docs/zh-tw/plugin-development/create-a-plugin.md
+++ b/docs/zh-tw/plugin-development/create-a-plugin.md
@@ -11,8 +11,8 @@ category: plugin-development
 order: 10
 translation:
   sourceFile: docs/plugin-development/create-a-plugin.md
-  sourceCommit: 36ab046b5f27060274a79d160c9b43606652d780
-  sourceBlob: 696795761c75dcd20b8b54e2dafd4012fd37c178
+  sourceCommit: 16dc72d27d06160bfb9a659139220b4c08545482
+  sourceBlob: 62bd4c1e6798190f8c810d09061d5f8e6889f1ff
 ---
 
 # 建立外掛 {#create-a-plugin}
@@ -75,7 +75,7 @@ defineEnginePlugin({
 })
 ```
 
-建置整合會監看這些路徑，並在其中之一變更時重新建立引擎（見 [SSR 與正式環境](/zh-tw/integrations/ssr-and-production#what-triggers-a-reload-in-dev)）。少了這個，使用者就必須重新啟動開發伺服器，才能套用你外掛原始檔的變更。`@pikacss/plugin-design-tokens` 正是這樣重新載入 token 檔的。
+建置整合會監看這些路徑，並在其中之一變更時重新建立引擎——確切地說是在它的*內容*變更時，所以一個位元組維持不變的相依會被視為沒有變更，即使它的意義已經改變（見 [SSR 與正式環境](/zh-tw/integrations/ssr-and-production#what-triggers-a-reload-in-dev)）。少了這個，使用者就必須重新啟動開發伺服器，才能套用你外掛原始檔的變更。`@pikacss/plugin-design-tokens` 正是這樣重新載入 token 檔的。
 
 ## 測試外掛 {#testing-a-plugin}
 

--- a/packages/unplugin/src/index.test.ts
+++ b/packages/unplugin/src/index.test.ts
@@ -68,9 +68,17 @@ function createCtxStub() {
 		usages: new Map([
 			['src/demo.ts', [{ atomicStyleIds: ['pk-a'] }]],
 		]),
+		// Mirrors the real ctx: a successful setup swaps in a brand-new engine
+		// instance, which is how the plugin tells a real re-derivation apart from
+		// the retain-last-good path. `retainEngine` opts into that second case.
+		retainEngine: false,
 		setup: vi.fn(async () => {
 			hooks.styleUpdated.listeners.length = 0
 			hooks.tsCodegenUpdated.listeners.length = 0
+			// New identity, same surface: tests that configure the engine (e.g.
+			// `configDependencies`) must keep seeing what they set.
+			if (!stub.retainEngine)
+				stub.engine = { ...stub.engine }
 		}),
 		fullyCssCodegen: vi.fn(async () => {}),
 		writeCssCodegenFile: vi.fn(async () => {}),
@@ -147,12 +155,14 @@ describe('unpluginFactory', () => {
 		mockCreateCtx.mockReturnValue(ctx)
 		const mod = await import('./index')
 		const plugin = mod.unpluginFactory(undefined, { framework: 'vite' } as any) as any
+		const demoMod = { id: 'src/demo.ts' }
 		const viteServer = {
 			moduleGraph: {
-				getModuleById: vi.fn(() => ({ id: 'src/demo.ts' })),
+				getModuleById: vi.fn(() => demoMod),
 				invalidateModule: vi.fn(),
 			},
 			reloadModule: vi.fn(async () => {}),
+			hot: { send: vi.fn() },
 		}
 
 		expect(mockCreateCtx)
@@ -211,9 +221,7 @@ describe('unpluginFactory', () => {
 		expect(viteServer.moduleGraph.getModuleById)
 			.toHaveBeenCalledWith('src/demo.ts')
 		expect(viteServer.moduleGraph.invalidateModule)
-			.toHaveBeenCalledWith({ id: 'src/demo.ts' })
-		expect(viteServer.reloadModule)
-			.toHaveBeenCalledWith({ id: 'src/demo.ts' })
+			.toHaveBeenCalledWith(demoMod)
 
 		const cssWritesBefore = ctx.writeCssCodegenFile.mock.calls.length
 		const tsWritesBefore = ctx.writeTsCodegenFile.mock.calls.length
@@ -228,6 +236,86 @@ describe('unpluginFactory', () => {
 			.toBe(1)
 	})
 
+	it('invalidates every module variant of a usage file and forces a full reload on re-derivation', async () => {
+		const ctx = createCtxStub()
+		mockCreateCtx.mockReturnValue(ctx)
+		const mod = await import('./index')
+		const plugin = mod.unpluginFactory(undefined, { framework: 'vite' } as any) as any
+		// A Vue SFC owns several module graph nodes; `ctx.usages` only knows the
+		// query-stripped file path, so `getModuleById` reaches just the main one.
+		const mainMod = { id: 'src/demo.ts' }
+		const templateMod = { id: 'src/demo.ts?vue&type=template' }
+		const viteServer = {
+			moduleGraph: {
+				getModuleById: vi.fn(() => mainMod),
+				getModulesByFile: vi.fn(() => new Set([mainMod, templateMod])),
+				invalidateModule: vi.fn(),
+			},
+			reloadModule: vi.fn(async () => {}),
+			hot: { send: vi.fn() },
+		}
+
+		plugin.vite.configResolved?.({ root: '/app', command: 'serve' } as any)
+		plugin.vite.configureServer?.(viteServer as any)
+		await plugin.buildStart.call({ addWatchFile: vi.fn() } as any)
+
+		mockReadFileSync.mockReturnValue('after')
+		plugin.watchChange?.('/tmp/pika.config.ts')
+		await flushAsyncWork()
+
+		expect(viteServer.moduleGraph.getModulesByFile)
+			.toHaveBeenCalledWith('src/demo.ts')
+		expect(viteServer.moduleGraph.invalidateModule)
+			.toHaveBeenCalledWith(templateMod)
+		expect(viteServer.moduleGraph.invalidateModule)
+			.toHaveBeenCalledWith(mainMod)
+		expect(viteServer.hot.send)
+			.toHaveBeenCalledWith({ type: 'full-reload' })
+		// `reloadModule` only broadcasts an HMR message — no server-side
+		// transform — so it buys nothing ahead of a full reload.
+		expect(viteServer.reloadModule)
+			.not
+			.toHaveBeenCalled()
+	})
+
+	it('skips invalidation and reload when setup retained the previous engine', async () => {
+		const ctx = createCtxStub()
+		// A config edit that fails to evaluate keeps the last-good engine, its
+		// store, and every usage: no atomic style id moved, so blowing away the
+		// page's state would be pure collateral damage.
+		ctx.retainEngine = true
+		mockCreateCtx.mockReturnValue(ctx)
+		const mod = await import('./index')
+		const plugin = mod.unpluginFactory(undefined, { framework: 'vite' } as any) as any
+		const mainMod = { id: 'src/demo.ts' }
+		const viteServer = {
+			moduleGraph: {
+				getModuleById: vi.fn(() => mainMod),
+				getModulesByFile: vi.fn(() => new Set([mainMod])),
+				invalidateModule: vi.fn(),
+			},
+			reloadModule: vi.fn(async () => {}),
+			hot: { send: vi.fn() },
+		}
+
+		plugin.vite.configResolved?.({ root: '/retained-app', command: 'serve' } as any)
+		plugin.vite.configureServer?.(viteServer as any)
+		await plugin.buildStart.call({ addWatchFile: vi.fn() } as any)
+
+		mockReadFileSync.mockReturnValue('after')
+		plugin.watchChange?.('/tmp/pika.config.ts')
+		await flushAsyncWork()
+
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(2)
+		expect(viteServer.moduleGraph.invalidateModule)
+			.not
+			.toHaveBeenCalled()
+		expect(viteServer.hot.send)
+			.not
+			.toHaveBeenCalled()
+	})
+
 	it('treats missing vite modules as a no-op during reload invalidation', async () => {
 		const ctx = createCtxStub()
 		mockCreateCtx.mockReturnValue(ctx)
@@ -239,6 +327,7 @@ describe('unpluginFactory', () => {
 				invalidateModule: vi.fn(),
 			},
 			reloadModule: vi.fn(async () => {}),
+			hot: { send: vi.fn() },
 		}
 
 		plugin.vite.configResolved?.({ root: '/no-module-app', command: 'serve' } as any)
@@ -251,8 +340,10 @@ describe('unpluginFactory', () => {
 
 		expect(viteServer.moduleGraph.invalidateModule)
 			.not.toHaveBeenCalled()
-		expect(viteServer.reloadModule)
-			.not.toHaveBeenCalled()
+		// Nothing to invalidate, but the ids were still reassigned, so whatever
+		// the browser is holding has to go.
+		expect(viteServer.hot.send)
+			.toHaveBeenCalledWith({ type: 'full-reload' })
 	})
 
 	it('supports webpack build mode, watches config changes, and adds config files during transform', async () => {
@@ -344,10 +435,27 @@ describe('unpluginFactory', () => {
 		expect(ctx.setup)
 			.toHaveBeenCalledTimes(1)
 
+		// Touched but byte-identical: re-deriving would reassign every atomic
+		// style id for nothing, so it must not happen.
+		plugin.watchChange?.('/tmp/design.md')
+		await flushAsyncWork()
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(1)
+
+		mockReadFileSync.mockReturnValue('after')
 		plugin.watchChange?.('/tmp/design.md')
 		await flushAsyncWork()
 		expect(ctx.setup)
 			.toHaveBeenCalledTimes(2)
+
+		// Deleted or unreadable counts as changed, not as unchanged.
+		mockReadFileSync.mockImplementation(() => {
+			throw new Error('ENOENT')
+		})
+		plugin.watchChange?.('/tmp/design.md')
+		await flushAsyncWork()
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(3)
 	})
 
 	it('drops usages of deleted source files and rewrites generated outputs', async () => {

--- a/packages/unplugin/src/index.test.ts
+++ b/packages/unplugin/src/index.test.ts
@@ -159,6 +159,7 @@ describe('unpluginFactory', () => {
 		const viteServer = {
 			moduleGraph: {
 				getModuleById: vi.fn(() => demoMod),
+				getModulesByFile: vi.fn(() => new Set([demoMod])),
 				invalidateModule: vi.fn(),
 			},
 			reloadModule: vi.fn(async () => {}),
@@ -324,6 +325,7 @@ describe('unpluginFactory', () => {
 		const viteServer = {
 			moduleGraph: {
 				getModuleById: vi.fn(() => undefined),
+				getModulesByFile: vi.fn(() => undefined),
 				invalidateModule: vi.fn(),
 			},
 			reloadModule: vi.fn(async () => {}),
@@ -448,10 +450,44 @@ describe('unpluginFactory', () => {
 		expect(ctx.setup)
 			.toHaveBeenCalledTimes(2)
 
+		// Saving the same content again after a real change is a no-op: the
+		// successful setup refreshed the snapshot.
+		plugin.watchChange?.('/tmp/design.md')
+		await flushAsyncWork()
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(2)
+
 		// Deleted or unreadable counts as changed, not as unchanged.
 		mockReadFileSync.mockImplementation(() => {
 			throw new Error('ENOENT')
 		})
+		plugin.watchChange?.('/tmp/design.md')
+		await flushAsyncWork()
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(3)
+	})
+
+	it('keeps retrying a config dependency whose setup retained the previous engine', async () => {
+		const ctx = createCtxStub() as any
+		ctx.engine.configDependencies = new Set(['/tmp/design.md'])
+		mockCreateCtx.mockReturnValue(ctx)
+		const mod = await import('./index')
+		const plugin = mod.unpluginFactory(undefined, { framework: 'vite' } as any) as any
+
+		await plugin.buildStart.call({ addWatchFile: vi.fn() } as any)
+
+		// From here every setup fails and keeps the last-good engine, so the live
+		// engine never consumes the new content.
+		ctx.retainEngine = true
+		mockReadFileSync.mockReturnValue('after')
+		plugin.watchChange?.('/tmp/design.md')
+		await flushAsyncWork()
+		expect(ctx.setup)
+			.toHaveBeenCalledTimes(2)
+
+		// Saving the identical content again must retry rather than be dismissed
+		// as unchanged: recording it on the watcher side would strand the engine
+		// on the old contents with nothing left to trigger a reload.
 		plugin.watchChange?.('/tmp/design.md')
 		await flushAsyncWork()
 		expect(ctx.setup)

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -149,6 +149,12 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 	// limit: assumes identical bytes produce an identical engine — the same
 	// assumption the config-file check has always made. A dependency that reads
 	// an env var, the clock, or an unregistered file breaks it.
+	// limit: the snapshot is read just after `ctx.setup()` returns, not by the
+	// engine as it consumes the file, so a write landing inside that window is
+	// recorded as already-seen and its reload is skipped. Closing it would mean
+	// having the engine report the bytes it actually read. The window is short
+	// and a later edit recovers; a watcher configured with a long
+	// `awaitWriteFinish` widens it.
 	const configDependencyContents = new Map<string, string | null>()
 	function readFileOrNull(path: string) {
 		try {
@@ -317,9 +323,6 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 			await ctx.setup()
 			lastSetupCwd = ctx.cwd
 			pendingSetupCwd = null
-			await debouncedWriteCssCodegenFile()
-			await debouncedWriteTsCodegenFile()
-			bindHooks()
 
 			// `ctx.setup()` swaps in a new engine only when it actually built one.
 			// A config edit that fails to evaluate takes the retain-last-good path
@@ -327,9 +330,20 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 			// no atomic style id moved and there is nothing to reload. Reloading
 			// anyway would throw away the page's state on every typo mid-edit.
 			const rederived = currentEngine() !== previousEngine
-			// The new engine may register a different dependency set (or the same
-			// files with content that moved on since the last snapshot).
-			snapshotConfigDependencies()
+
+			// Snapshot the dependency contents the live engine actually consumed —
+			// it read them inside `ctx.setup()` just above, so this must happen
+			// before the debounced writes below, or an edit landing in between
+			// would be recorded as already-seen and never reloaded. Skipping the
+			// refresh when the engine was retained is what makes the watcher
+			// self-healing: the stale snapshot keeps disagreeing with the file
+			// until a setup finally succeeds.
+			if (rederived)
+				snapshotConfigDependencies()
+
+			await debouncedWriteCssCodegenFile()
+			await debouncedWriteTsCodegenFile()
+			bindHooks()
 
 			if (reload && rederived) {
 				if (meta.framework === 'vite') {
@@ -343,7 +357,7 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 							// see the full-reload note below for why a survivor is not
 							// merely stale but wrong.
 							for (const mod of collectViteModules(server, id)) {
-								log.debug(`Invalidating module: ${mod.id ?? mod.url ?? id}`)
+								log.debug(`Invalidating module: ${mod.url}`)
 								server.moduleGraph.invalidateModule(mod)
 							}
 						})
@@ -592,12 +606,14 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 			// Same content-comparison rule the config file gets: re-deriving is
 			// what reassigns every atomic style id, so it must not be triggered by
 			// a save that changed nothing.
-			const currentContent = readFileOrNull(id)
-			if (currentContent === configDependencyContents.get(id)) {
+			// The map is written only by a successful setup, never here: recording
+			// bytes the engine may never consume (the setup below can fail and
+			// retain the previous engine) would make an unchanged re-save look
+			// like a no-op and strand the engine on the old contents.
+			if (readFileOrNull(id) === configDependencyContents.get(id)) {
 				log.debug(`Config dependency touched but unchanged, skipping reload: ${id}`)
 				return
 			}
-			configDependencyContents.set(id, currentContent)
 			log.info(`Config dependency changed: ${id}, reloading...`)
 			pendingReload = true
 			debouncedSetup(true)
@@ -615,9 +631,7 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
  */
 function collectViteModules(server: ViteDevServer, id: string) {
 	const modules = new Set<NonNullable<ReturnType<ViteDevServer['moduleGraph']['getModuleById']>>>()
-	// limit: `getModulesByFile` is absent on hand-rolled server stubs; the
-	// `getModuleById` fallback keeps the main node covered either way.
-	server.moduleGraph.getModulesByFile?.(id)
+	server.moduleGraph.getModulesByFile(id)
 		?.forEach(mod => modules.add(mod))
 	const byId = server.moduleGraph.getModuleById(id)
 	if (byId)

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -129,6 +129,46 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 		onDiagnostic,
 	})
 
+	// `ctx.engine` throws before the first successful setup; identity comparison
+	// of the returned instance is what tells a real re-derivation apart from the
+	// retain-last-good path, where the engine object is left in place.
+	function currentEngine() {
+		try {
+			return ctx.engine
+		}
+		catch {
+			return null
+		}
+	}
+
+	// Last-seen content of every file a plugin registered through
+	// `engine.addConfigDependency`. The context already does this for the config
+	// file itself (`ctx.resolvedConfigContent`); mirroring it here keeps a bare
+	// `touch`, or a save that changes nothing, from re-deriving the engine and
+	// reloading the page.
+	// limit: assumes identical bytes produce an identical engine — the same
+	// assumption the config-file check has always made. A dependency that reads
+	// an env var, the clock, or an unregistered file breaks it.
+	const configDependencyContents = new Map<string, string | null>()
+	function readFileOrNull(path: string) {
+		try {
+			return readFileSync(path, 'utf-8')
+		}
+		catch {
+			// Deleted or unreadable: recorded as null so the next readable state
+			// counts as a change.
+			return null
+		}
+	}
+	function snapshotConfigDependencies() {
+		const deps = currentEngine()?.configDependencies
+		if (deps == null)
+			return
+		configDependencyContents.clear()
+		for (const dep of deps)
+			configDependencyContents.set(dep, readFileOrNull(dep))
+	}
+
 	// Logs a design-token usage summary (and optionally writes the full JSON) at
 	// build end. Duck-typed access to the engine augmentation avoids depending on
 	// the design-tokens plugin; when it is not registered, this is a no-op.
@@ -267,6 +307,7 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 		setupPromise = setupPromise.then(async () => {
 			log.debug('Setting up integration context...')
 			const moduleIds = Array.from(ctx.usages.keys())
+			const previousEngine = currentEngine()
 			pendingCssWrite = false
 			pendingTsWrite = false
 			// generatedWritePromise is intentionally not reset: the promise chain's
@@ -280,20 +321,54 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 			await debouncedWriteTsCodegenFile()
 			bindHooks()
 
-			if (reload) {
+			// `ctx.setup()` swaps in a new engine only when it actually built one.
+			// A config edit that fails to evaluate takes the retain-last-good path
+			// instead: the engine, its store, and every usage survive untouched, so
+			// no atomic style id moved and there is nothing to reload. Reloading
+			// anyway would throw away the page's state on every typo mid-edit.
+			const rederived = currentEngine() !== previousEngine
+			// The new engine may register a different dependency set (or the same
+			// files with content that moved on since the last snapshot).
+			snapshotConfigDependencies()
+
+			if (reload && rederived) {
 				if (meta.framework === 'vite') {
-					const promises = [] as Promise<void>[]
 					moduleIds.forEach((id) => {
 						viteServers.forEach((server) => {
-							const mod = server.moduleGraph.getModuleById(id)
-							if (mod) {
-								log.debug(`Invalidating and reloading module: ${id}`)
+							// One source file can own several module graph nodes: a Vue
+							// SFC's template and style blocks live under their own
+							// `?vue&type=...` ids, and `ctx.usages` is keyed by the
+							// query-stripped file path, so `getModuleById` alone reaches
+							// only the main node. Every node has to be invalidated —
+							// see the full-reload note below for why a survivor is not
+							// merely stale but wrong.
+							for (const mod of collectViteModules(server, id)) {
+								log.debug(`Invalidating module: ${mod.id ?? mod.url ?? id}`)
 								server.moduleGraph.invalidateModule(mod)
-								promises.push(server.reloadModule(mod))
 							}
 						})
 					})
-					await Promise.all(promises)
+
+					// A re-derived engine restarts atomic style id assignment from
+					// zero, so the same declaration can come back under a different
+					// name and a name can be handed to a different declaration. The
+					// regenerated CSS reaches the browser immediately, so any module
+					// still served from a previous transform does not just look stale
+					// — its class names may now resolve to somebody else's rule, with
+					// no error to show for it. A full page reload is the only way to
+					// guarantee the browser never holds JS and CSS from two different
+					// id generations.
+					//
+					// The invalidated modules re-transform when the reloaded page
+					// requests them, which is also what refills the engine store and
+					// the generated CSS. `server.reloadModule` is deliberately not
+					// used: it only broadcasts an HMR message (no server-side
+					// transform), so it would buy nothing here and its update would be
+					// superseded by this reload anyway.
+					viteServers.forEach((server) => {
+						log.debug('Triggering full page reload after engine re-derivation')
+						server.hot.send({ type: 'full-reload' })
+					})
 				}
 
 				else if (meta.framework === 'rspack') {
@@ -510,20 +585,44 @@ export const unpluginFactory: UnpluginFactory<PluginOptions | undefined> = (opti
 				}
 				return
 			}
-			let isConfigDependency = false
-			try {
-				isConfigDependency = ctx.engine.configDependencies.has(id)
+			// currentEngine() is null before the first setup; nothing to reload.
+			if (currentEngine()?.configDependencies?.has(id) !== true)
+				return
+
+			// Same content-comparison rule the config file gets: re-deriving is
+			// what reassigns every atomic style id, so it must not be triggered by
+			// a save that changed nothing.
+			const currentContent = readFileOrNull(id)
+			if (currentContent === configDependencyContents.get(id)) {
+				log.debug(`Config dependency touched but unchanged, skipping reload: ${id}`)
+				return
 			}
-			catch {
-				// Engine not initialized yet; nothing to reload.
-			}
-			if (isConfigDependency) {
-				log.info(`Config dependency changed: ${id}, reloading...`)
-				pendingReload = true
-				debouncedSetup(true)
-			}
+			configDependencyContents.set(id, currentContent)
+			log.info(`Config dependency changed: ${id}, reloading...`)
+			pendingReload = true
+			debouncedSetup(true)
 		},
 	}
+}
+
+/**
+ * Collects every module graph node that a source file owns.
+ * @internal
+ *
+ * @param server - The Vite dev server whose module graph is queried.
+ * @param id - A `ctx.usages` key: an absolute, query-stripped file path.
+ * @returns The deduplicated set of modules registered for that file, including query-suffixed variants such as a Vue SFC's `?vue&type=template` node.
+ */
+function collectViteModules(server: ViteDevServer, id: string) {
+	const modules = new Set<NonNullable<ReturnType<ViteDevServer['moduleGraph']['getModuleById']>>>()
+	// limit: `getModulesByFile` is absent on hand-rolled server stubs; the
+	// `getModuleById` fallback keeps the main node covered either way.
+	server.moduleGraph.getModulesByFile?.(id)
+		?.forEach(mod => modules.add(mod))
+	const byId = server.moduleGraph.getModuleById(id)
+	if (byId)
+		modules.add(byId)
+	return [...modules]
 }
 
 /**

--- a/packages/unplugin/src/index.vite-dev.test.ts
+++ b/packages/unplugin/src/index.vite-dev.test.ts
@@ -1,13 +1,13 @@
 import type { Plugin, ViteDevServer } from 'vite'
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'pathe'
 import { createServer } from 'vite'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// limit: this collapses both the setup debounce and the 300ms codegen-write
-// debounce, so the ordering between the full reload and the CSS write is not
-// what this test covers — only the module graph invalidation is.
+// limit: this collapses both the setup debounce and the codegen-write debounce,
+// so the ordering between the full reload and the CSS write is not what these
+// tests cover.
 vi.mock('perfect-debounce', () => ({
 	debounce: (fn: (...args: any[]) => any) => (...args: any[]) => fn(...args),
 }))
@@ -16,6 +16,11 @@ vi.mock('perfect-debounce', () => ({
 // short-circuits on `vue&type=`, so a made-up query would send the sub-module
 // down the `dropModule` path instead and stop mirroring the reported case.
 const TEMPLATE_QUERY = '?vue&type=template'
+
+// Comfortably inside the explicit per-test timeouts, so a failure reports the
+// assertion that actually failed instead of being cut short by Vitest.
+const WAIT_TIMEOUT = 5_000
+const TEST_TIMEOUT = 20_000
 
 const createdDirs: string[] = []
 const createdServers: ViteDevServer[] = []
@@ -35,11 +40,11 @@ async function createTempDir() {
  * It is not an SFC compiler and makes no claim beyond that module shape.
  *
  * It deliberately has no `enforce`, so it runs *after* PikaCSS's `pre`
- * transform and carries PikaCSS's already-rewritten output — the same ordering
+ * transform and stashes PikaCSS's already-rewritten output — the same ordering
  * that makes a Vue SFC's template block hold generated class names that were
  * never registered under the sub-module's own id.
  */
-function createSplittingPlugin(templateUrl: string): Plugin {
+function createSplittingPlugin(): Plugin {
 	const templateCode = new Map<string, string>()
 	return {
 		name: 'test:split-into-sub-module',
@@ -49,23 +54,34 @@ function createSplittingPlugin(templateUrl: string): Plugin {
 			return templateCode.get(id) ?? null
 		},
 		transform(code, id) {
-			if (id.includes(TEMPLATE_QUERY) || !id.endsWith('Comp.ts'))
+			if (id.includes(TEMPLATE_QUERY) || !id.endsWith('.ts'))
 				return null
 			templateCode.set(`${id}${TEMPLATE_QUERY}`, code)
-			return `export * from ${JSON.stringify(templateUrl)}`
+			const basename = id.slice(id.lastIndexOf('/') + 1)
+			return `export * from ${JSON.stringify(`/src/${basename}${TEMPLATE_QUERY}`)}`
 		},
 	}
 }
 
-async function setupProject() {
+function templateUrlOf(name: string) {
+	return `/src/${name}.ts${TEMPLATE_QUERY}`
+}
+
+/**
+ * Writes a project whose components each declare one `color`, boots a real Vite
+ * dev server over it, and returns handles for driving requests by component.
+ */
+async function setupProject(components: Record<string, string>) {
 	const root = await createTempDir()
 	await mkdir(join(root, 'src'), { recursive: true })
 	await writeFile(join(root, 'pika.config.ts'), 'export default {}\n', 'utf8')
-	await writeFile(
-		join(root, 'src/Comp.ts'),
-		'export const cls = pika({ color: \'red\' })\n',
-		'utf8',
-	)
+	for (const [name, color] of Object.entries(components)) {
+		await writeFile(
+			join(root, `src/${name}.ts`),
+			`export const cls = pika({ color: '${color}' })\n`,
+			'utf8',
+		)
+	}
 
 	const { default: pikacss } = await import('./vite')
 	const pikaPlugin = pikacss({
@@ -74,7 +90,6 @@ async function setupProject() {
 		tsCodegen: false,
 		autoCreateConfig: false,
 	})
-	const templateUrl = `/src/Comp.ts${TEMPLATE_QUERY}`
 	const server = await createServer({
 		root,
 		configFile: false,
@@ -82,22 +97,41 @@ async function setupProject() {
 		optimizeDeps: { noDiscovery: true },
 		appType: 'custom',
 		server: { middlewareMode: true, watch: null },
-		plugins: [pikaPlugin, createSplittingPlugin(templateUrl)],
+		plugins: [pikaPlugin, createSplittingPlugin()],
 	})
 	createdServers.push(server)
 
-	// Populate the graph the way a browser would: the main module first, then
-	// the sub-module it imports.
-	await server.transformRequest('/src/Comp.ts')
-	await server.transformRequest(templateUrl)
-
-	const compFile = join(root, 'src/Comp.ts')
-	return { root, server, compFile, templateUrl, pikaPlugin: [pikaPlugin].flat() }
+	return {
+		root,
+		server,
+		plugins: [pikaPlugin].flat(),
+		fileOf: (name: string) => join(root, `src/${name}.ts`),
+		// The graph keys sub-nodes by their resolved id, not by the request URL,
+		// so look them up through the file that owns them.
+		subNodeOf: (name: string) => {
+			const nodes = server.moduleGraph.getModulesByFile(join(root, `src/${name}.ts`))
+			return [...nodes ?? []].find(node => node.id?.includes(TEMPLATE_QUERY))
+		},
+		// Populate the graph the way a browser would: the main module first, then
+		// the sub-module it imports.
+		request: async (name: string) => {
+			await server.transformRequest(`/src/${name}.ts`)
+			return server.transformRequest(templateUrlOf(name))
+		},
+		readCss: () => readFile(join(root, 'pika.gen.css'), 'utf8'),
+		// The watcher is off (`watch: null`), so the bundler hook is driven
+		// directly. That means these tests do not cover the watcher-to-hook edge.
+		changeConfig: async (body: string) => {
+			await writeFile(join(root, 'pika.config.ts'), `export default ${body}\n`, 'utf8')
+			const hook = [pikaPlugin].flat()
+				.map(plugin => plugin.watchChange)
+				.find(candidate => typeof candidate === 'function')
+			if (hook == null)
+				throw new Error('watchChange hook not found on the PikaCSS Vite plugin')
+			await hook.call({} as any, join(root, 'pika.config.ts'), { event: 'update' })
+		},
+	}
 }
-
-// Comfortably inside the explicit `testTimeout` below, so a failure reports the
-// assertion that actually failed instead of being cut short by Vitest.
-const WAIT_TIMEOUT = 5_000
 
 async function waitFor(predicate: () => boolean, timeout = WAIT_TIMEOUT) {
 	const deadline = Date.now() + timeout
@@ -109,60 +143,140 @@ async function waitFor(predicate: () => boolean, timeout = WAIT_TIMEOUT) {
 	return true
 }
 
-function getWatchChange(plugins: Plugin[]) {
-	for (const plugin of plugins) {
-		const hook = plugin.watchChange
-		if (typeof hook === 'function')
-			return hook.bind(plugin)
+async function waitForAsync(predicate: () => Promise<boolean>, timeout = WAIT_TIMEOUT) {
+	const deadline = Date.now() + timeout
+	while (!(await predicate())) {
+		if (Date.now() > deadline)
+			return false
+		await new Promise<void>(resolve => setTimeout(resolve, 10))
 	}
-	throw new Error('watchChange hook not found on the PikaCSS Vite plugin')
+	return true
+}
+
+function spyOnFullReload(server: ViteDevServer) {
+	const calls: any[] = []
+	vi.spyOn(server.hot, 'send')
+		.mockImplementation(((payload: any) => {
+			calls.push(payload)
+		}) as any)
+	return {
+		calls,
+		seen: () => calls.some(payload => payload?.type === 'full-reload'),
+	}
+}
+
+function classNameIn(code: string | null | undefined) {
+	return code?.match(/pk-[A-Za-z]+/)?.[0]
+}
+
+function cssRulesOf(css: string) {
+	const rules = new Map<string, string>()
+	for (const [, id, color] of css.matchAll(/\.(pk-[A-Za-z]+)\s*\{\s*color:\s*([a-z]+)/g))
+		rules.set(id!, color!)
+	return rules
 }
 
 afterEach(async () => {
 	vi.restoreAllMocks()
 
-	while (createdServers.length > 0)
-		await createdServers.pop()!.close()
-
-	while (createdDirs.length > 0)
-		await rm(createdDirs.pop()!, { recursive: true, force: true })
+	// Each teardown step is independent: one failure must not strand the rest.
+	await Promise.allSettled(createdServers.splice(0)
+		.map(server => server.close()))
+	await Promise.allSettled(createdDirs.splice(0)
+		.map(dir =>
+		// Windows can hold a handle on a directory Vite just touched.
+			rm(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 }),
+		))
 })
 
 describe('vite dev server re-derivation', () => {
 	it('invalidates every module graph node of a usage file and forces a full reload', async () => {
-		const { root, server, compFile, templateUrl, pikaPlugin } = await setupProject()
+		const project = await setupProject({ Comp: 'red' })
+		await project.request('Comp')
 
-		const nodes = server.moduleGraph.getModulesByFile(compFile)
+		const nodes = project.server.moduleGraph.getModulesByFile(project.fileOf('Comp'))
 		// The precondition the bug depended on: one file, several graph nodes,
 		// only one of which `getModuleById(file)` can reach.
 		expect(nodes?.size)
-			.toBe(2)
-		const subModule = server.moduleGraph.getModuleById(templateUrl)
-			?? [...nodes!].find(mod => mod.id?.includes(TEMPLATE_QUERY))
-		expect(subModule?.transformResult)
-			.not
-			.toBeNull()
+			.toBeGreaterThanOrEqual(2)
+		const subModule = project.subNodeOf('Comp')
+		expect(subModule)
+			.toBeDefined()
+		// Not just "it transformed" — it is holding a generated class name, which
+		// is what makes a survivor dangerous rather than merely stale.
+		expect(classNameIn(subModule!.transformResult?.code))
+			.toBeDefined()
 
-		const sendSpy = vi.fn()
-		const channel = (server as any).hot ?? (server as any).ws
-		vi.spyOn(channel, 'send')
-			.mockImplementation(sendSpy)
-
-		// Re-derive the engine: the config content changes, so every atomic
-		// style id is reassigned from scratch.
-		await writeFile(join(root, 'pika.config.ts'), 'export default { /* changed */ }\n', 'utf8')
-		await getWatchChange(pikaPlugin)(join(root, 'pika.config.ts'), { event: 'update' })
+		const reload = spyOnFullReload(project.server)
+		await project.changeConfig('{ /* changed */ }')
 		// The reload runs on the plugin's internal setup chain, which is not
 		// exposed; wait for its observable end state instead of a fixed delay.
-		const reloaded = await waitFor(() => sendSpy.mock.calls.length > 0)
+		const reloaded = await waitFor(reload.seen)
 
 		expect(reloaded)
 			.toBe(true)
-		expect(sendSpy)
-			.toHaveBeenCalledWith({ type: 'full-reload' })
 		// Without the fix this sub-module keeps its previous transform result —
 		// class names from the old id generation, served against the new CSS.
-		expect(subModule?.transformResult)
+		expect(subModule!.transformResult)
 			.toBeNull()
-	}, 20_000)
+	}, TEST_TIMEOUT)
+
+	it('never serves a class name that the regenerated CSS assigns to another rule', async () => {
+		// Two components so the id space can actually be reshuffled: ids are
+		// handed out in discovery order, so re-deriving and then re-requesting in
+		// the opposite order swaps which declaration owns which name.
+		const project = await setupProject({ Alpha: 'red', Beta: 'blue' })
+		await project.request('Alpha')
+		await project.request('Beta')
+
+		const before = classNameIn(
+			project.subNodeOf('Alpha')?.transformResult?.code,
+		)
+		expect(before)
+			.toBeDefined()
+
+		const reload = spyOnFullReload(project.server)
+		await project.changeConfig('{ /* changed */ }')
+		expect(await waitFor(reload.seen))
+			.toBe(true)
+
+		// The reloaded page requests modules in whatever order it resolves them —
+		// here the reverse of the first pass, which is what moves Alpha off its
+		// original name.
+		await project.request('Beta')
+		await project.request('Alpha')
+
+		const alpha = classNameIn(
+			project.subNodeOf('Alpha')?.transformResult?.code,
+		)
+		const beta = classNameIn(
+			project.subNodeOf('Beta')?.transformResult?.code,
+		)
+		expect(alpha)
+			.toBeDefined()
+		expect(beta)
+			.toBeDefined()
+		// Names really did move; otherwise the assertion below would pass for the
+		// wrong reason.
+		expect(alpha)
+			.not
+			.toBe(before)
+
+		// The codegen write lands off the request path, so poll for it rather
+		// than assuming it already happened.
+		let rules = new Map<string, string>()
+		const cssReady = await waitForAsync(async () => {
+			rules = cssRulesOf(await project.readCss())
+			return rules.has(alpha!) && rules.has(beta!)
+		})
+		expect(cssReady)
+			.toBe(true)
+
+		// The reported failure in one line: the class the module serves must be
+		// the class the CSS gives that module's own declaration.
+		expect(rules.get(alpha!))
+			.toBe('red')
+		expect(rules.get(beta!))
+			.toBe('blue')
+	}, TEST_TIMEOUT)
 })

--- a/packages/unplugin/src/index.vite-dev.test.ts
+++ b/packages/unplugin/src/index.vite-dev.test.ts
@@ -1,0 +1,168 @@
+import type { Plugin, ViteDevServer } from 'vite'
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+import { createServer } from 'vite'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// limit: this collapses both the setup debounce and the 300ms codegen-write
+// debounce, so the ordering between the full reload and the CSS write is not
+// what this test covers — only the module graph invalidation is.
+vi.mock('perfect-debounce', () => ({
+	debounce: (fn: (...args: any[]) => any) => (...args: any[]) => fn(...args),
+}))
+
+// The real query `@vitejs/plugin-vue` emits. It matters: `ctx.transform`
+// short-circuits on `vue&type=`, so a made-up query would send the sub-module
+// down the `dropModule` path instead and stop mirroring the reported case.
+const TEMPLATE_QUERY = '?vue&type=template'
+
+const createdDirs: string[] = []
+const createdServers: ViteDevServer[] = []
+
+async function createTempDir() {
+	// realpath matters: on macOS `os.tmpdir()` is a symlink, and Vite resolves
+	// module ids to their real path. A symlinked root makes every file look
+	// outside the served root and load-fallback refuses to read it.
+	const dir = await realpath(await mkdtemp(join(tmpdir(), 'pikacss-unplugin-vite-')))
+	createdDirs.push(dir)
+	return dir
+}
+
+/**
+ * Stand-in for `@vitejs/plugin-vue`, mirroring one property of it: a single
+ * source file owning a main module plus a `?vue&type=template` sub-module.
+ * It is not an SFC compiler and makes no claim beyond that module shape.
+ *
+ * It deliberately has no `enforce`, so it runs *after* PikaCSS's `pre`
+ * transform and carries PikaCSS's already-rewritten output — the same ordering
+ * that makes a Vue SFC's template block hold generated class names that were
+ * never registered under the sub-module's own id.
+ */
+function createSplittingPlugin(templateUrl: string): Plugin {
+	const templateCode = new Map<string, string>()
+	return {
+		name: 'test:split-into-sub-module',
+		load(id) {
+			if (!id.includes(TEMPLATE_QUERY))
+				return null
+			return templateCode.get(id) ?? null
+		},
+		transform(code, id) {
+			if (id.includes(TEMPLATE_QUERY) || !id.endsWith('Comp.ts'))
+				return null
+			templateCode.set(`${id}${TEMPLATE_QUERY}`, code)
+			return `export * from ${JSON.stringify(templateUrl)}`
+		},
+	}
+}
+
+async function setupProject() {
+	const root = await createTempDir()
+	await mkdir(join(root, 'src'), { recursive: true })
+	await writeFile(join(root, 'pika.config.ts'), 'export default {}\n', 'utf8')
+	await writeFile(
+		join(root, 'src/Comp.ts'),
+		'export const cls = pika({ color: \'red\' })\n',
+		'utf8',
+	)
+
+	const { default: pikacss } = await import('./vite')
+	const pikaPlugin = pikacss({
+		cwd: root,
+		cssCodegen: 'pika.gen.css',
+		tsCodegen: false,
+		autoCreateConfig: false,
+	})
+	const templateUrl = `/src/Comp.ts${TEMPLATE_QUERY}`
+	const server = await createServer({
+		root,
+		configFile: false,
+		logLevel: 'silent',
+		optimizeDeps: { noDiscovery: true },
+		appType: 'custom',
+		server: { middlewareMode: true, watch: null },
+		plugins: [pikaPlugin, createSplittingPlugin(templateUrl)],
+	})
+	createdServers.push(server)
+
+	// Populate the graph the way a browser would: the main module first, then
+	// the sub-module it imports.
+	await server.transformRequest('/src/Comp.ts')
+	await server.transformRequest(templateUrl)
+
+	const compFile = join(root, 'src/Comp.ts')
+	return { root, server, compFile, templateUrl, pikaPlugin: [pikaPlugin].flat() }
+}
+
+// Comfortably inside the explicit `testTimeout` below, so a failure reports the
+// assertion that actually failed instead of being cut short by Vitest.
+const WAIT_TIMEOUT = 5_000
+
+async function waitFor(predicate: () => boolean, timeout = WAIT_TIMEOUT) {
+	const deadline = Date.now() + timeout
+	while (!predicate()) {
+		if (Date.now() > deadline)
+			return false
+		await new Promise<void>(resolve => setTimeout(resolve, 10))
+	}
+	return true
+}
+
+function getWatchChange(plugins: Plugin[]) {
+	for (const plugin of plugins) {
+		const hook = plugin.watchChange
+		if (typeof hook === 'function')
+			return hook.bind(plugin)
+	}
+	throw new Error('watchChange hook not found on the PikaCSS Vite plugin')
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks()
+
+	while (createdServers.length > 0)
+		await createdServers.pop()!.close()
+
+	while (createdDirs.length > 0)
+		await rm(createdDirs.pop()!, { recursive: true, force: true })
+})
+
+describe('vite dev server re-derivation', () => {
+	it('invalidates every module graph node of a usage file and forces a full reload', async () => {
+		const { root, server, compFile, templateUrl, pikaPlugin } = await setupProject()
+
+		const nodes = server.moduleGraph.getModulesByFile(compFile)
+		// The precondition the bug depended on: one file, several graph nodes,
+		// only one of which `getModuleById(file)` can reach.
+		expect(nodes?.size)
+			.toBe(2)
+		const subModule = server.moduleGraph.getModuleById(templateUrl)
+			?? [...nodes!].find(mod => mod.id?.includes(TEMPLATE_QUERY))
+		expect(subModule?.transformResult)
+			.not
+			.toBeNull()
+
+		const sendSpy = vi.fn()
+		const channel = (server as any).hot ?? (server as any).ws
+		vi.spyOn(channel, 'send')
+			.mockImplementation(sendSpy)
+
+		// Re-derive the engine: the config content changes, so every atomic
+		// style id is reassigned from scratch.
+		await writeFile(join(root, 'pika.config.ts'), 'export default { /* changed */ }\n', 'utf8')
+		await getWatchChange(pikaPlugin)(join(root, 'pika.config.ts'), { event: 'update' })
+		// The reload runs on the plugin's internal setup chain, which is not
+		// exposed; wait for its observable end state instead of a fixed delay.
+		const reloaded = await waitFor(() => sendSpy.mock.calls.length > 0)
+
+		expect(reloaded)
+			.toBe(true)
+		expect(sendSpy)
+			.toHaveBeenCalledWith({ type: 'full-reload' })
+		// Without the fix this sub-module keeps its previous transform result —
+		// class names from the old id generation, served against the new CSS.
+		expect(subModule?.transformResult)
+			.toBeNull()
+	}, 20_000)
+})


### PR DESCRIPTION
## Problem

Reported downstream (Vue 3 SPA, Vite 8, `@pikacss/unplugin-pikacss` 0.0.60): during a dev session, elements silently render with another component's styles. No error, no warning, no HMR failure — the page just collapses, and only a dev-server restart brings it back.

Root cause chain:

1. Atomic style ids are a discovery-order counter — `packages/core/src/atomic-style.ts:92-93` does `const num = stored.size; const id = prefix + numberToChars(num)`. The name says nothing about the declaration; `display: flex` gets `pk-Sa` only because it was the 45th style seen.
2. On a config or config-dependency change, `setup()` in `packages/integration/src/ctx.ts` builds a fresh engine and clears the store, so ids restart at `pk-a`. The same declaration can come back under a different name, and a name can be handed to a *different* declaration.
3. The regenerated `pika.gen.css` is hot-pushed immediately, but the Vite reload path only reached the module graph node returned by `getModuleById(file)`. `ctx.usages` is keyed by query-stripped file paths (`packages/integration/src/moduleId.ts:42`), so the other nodes one file owns — a Vue SFC's `?vue&type=template` block among them — were never invalidated. They kept serving class names from the previous id generation against the new CSS.

## Change

- **Invalidate every module graph node a usage file owns**, via a new `collectViteModules()` that unions `getModulesByFile(id)` with `getModuleById(id)`.
- **Force a full page reload** after invalidation. A surviving stale node is not merely stale — its class names may resolve to a different rule — so the browser must never hold JS and CSS from two id generations.
- **Drop `server.reloadModule`.** Verified against Vite 8 source: it only calls `updateModules` (broadcasts an HMR message, no server-side transform), so it bought nothing here and its update would be superseded by the reload. It is also a future-deprecated API.
- **Only reload when ids actually moved.** A full reload costs the page its state, so it is now gated on `ctx.setup()` having swapped in a new engine. A config edit that fails to evaluate takes the retain-last-good path — engine, store, and usages untouched, no id moved — and no longer blows away form/router/component state on every typo mid-edit.
- **Compare config-dependency content before re-deriving**, matching what the config file already does. A bare `touch`, or a save that changed nothing, no longer triggers a reload. Documented limit: this assumes identical bytes produce an identical engine, the same assumption the config-file check has always made.

## Tests

- `index.vite-dev.test.ts` (new) drives a **real Vite dev server**. A test-local plugin with no `enforce` runs after PikaCSS's `pre` transform and splits one file into a main node plus a `?vue&type=template` node — the SFC module shape, using the real query because `ctx.transform` short-circuits on `vue&type=`. It asserts the precondition (one file, two graph nodes), then that a config change invalidates the sub-node and broadcasts a full reload.
- `index.test.ts` adds the retained-engine skip, the multi-node invalidation, the no-graph-node case, and config-dependency content comparison including the unreadable-file case.
- Regression value confirmed by removal, not assumption: reverting `index.ts` fails 4 tests; disabling only the `collectViteModules` loop fails the integration test on its sub-node assertion.

## Validation

`pnpm --filter @pikacss/unplugin-pikacss test` → 13 files, 48 tests passed; statements 99.55%, branches 95.62%, functions 100%, lines 99.55% (thresholds 95%). `typecheck` and repo-wide `pnpm lint` clean.

## Not in scope

- **The positional id scheme is unchanged.** Deriving ids from a content hash would make the whole failure class impossible and stabilise build output, but it lengthens every class name and collides with the deliberate `num` disambiguation `getAtomicStyleStoredKey` uses for order-sensitive content. Owner call, separate change.
- Dev-server restart is a different path with no invalidation mechanism at all.
- A config change that produces byte-identical CSS still triggers a reload; detecting that needs a full before/after CSS comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
