### PR TITLE
ci: build before bumping so the pre-commit hook can run

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -51,10 +51,18 @@ jobs:
       - name: install dependencies
         run: pnpm install --frozen-lockfile
 
-      # No validate step here on purpose: CI runs the full gate on the release
-      # branch (ci.yml covers `release/**` pushes precisely so these required
-      # checks appear on the pull request) and again on main after the merge.
-      # The tree being published is therefore the tree that was checked.
+      # Required even though this workflow never publishes: bumpp's commit
+      # trips the pre-commit hook, whose eslint run resolves the workspace-local
+      # `@pikacss/eslint-config` through its `dist/`. Without a build that
+      # import does not exist and the commit fails.
+      #
+      # Still no full validate step: CI runs the whole gate on the release
+      # branch (ci.yml covers `release/**` pushes precisely so those required
+      # checks appear on the pull request) and again on main after the merge,
+      # so the tree being published is the tree that was checked.
+      - name: build workspace (needed by the pre-commit hook)
+        run: pnpm build
+
       - name: bump version on a release branch
         id: bump
         run: |


### PR DESCRIPTION
The first run of the new `release-prepare.yml` ([run 30278398043](https://github.com/pikacss/pikacss/actions/runs/30278398043)) failed at the bump step:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/home/runner/work/pikacss/pikacss/node_modules/@pikacss/eslint-config/dist/index.mjs'
imported from /home/runner/work/pikacss/pikacss/eslint.config.mjs
```

`bumpp` makes a commit, that commit trips the repository's pre-commit hook, and the hook's eslint run imports the workspace-local `@pikacss/eslint-config` through its `dist/`. Nothing had built it.

The workflow this replaced (#103) built the workspace as part of its `validate` step, so the hook always found `dist/` by accident. Dropping that step removed a dependency that was never explicit.

Fix: build before bumping. Not the full validate step — CI still runs the whole gate on the release branch and again on main after the merge, so the tree being published is still the tree that was checked.

Nothing was left behind by the failed run: it died on the commit, before the branch push, so there is no `release/*` branch, no pull request, no tag, and nothing on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)