### PR TITLE
chore: release v0.0.61

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "demo",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"engines": {
 		"node": ">=22"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/docs",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"description": "Documents for pikacss.",
 	"author": "DevilTea <ch19980814@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pikacss-monorepo",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"packageManager": "pnpm@10.34.4",
 	"description": "The instant on-demand atomic css-in-js engine.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/core",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/integration",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/nuxt-pikacss",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-design-tokens/package.json
+++ b/packages/plugin-design-tokens/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-fonts/package.json
+++ b/packages/plugin-fonts/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-icons/package.json
+++ b/packages/plugin-icons/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/plugin-icons",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-reset/package.json
+++ b/packages/plugin-reset/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-typography/package.json
+++ b/packages/plugin-typography/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/unplugin-pikacss",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/playground",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"engines": {
 		"node": ">=22"


### PR DESCRIPTION
Version bump to `v0.0.61`, produced by `release-prepare.yml` ([run 30279905860](https://github.com/pikacss/pikacss/actions/runs/30279905860)).

**Merging this pull request publishes to npm.** `release-publish.yml` reacts to the merge: it tags the merged commit `v0.0.61`, publishes every package under `packages/` with npm trusted publishing, writes the GitHub release notes, and redeploys the docs.

### Why this pull request was opened by hand

The workflow got as far as pushing the branch, then failed:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

That is a repository setting ("Allow GitHub Actions to create and approve pull requests"), off by default. Opening the pull request manually is equivalent — and it has a side benefit for this first run: a pull request opened by a real account triggers CI, whereas one opened with `GITHUB_TOKEN` would not have. Stage 1 needs a follow-up fix; stage 2 is exercised by merging this.

### What is in it

`bumpp -r patch` across 14 manifests, `0.0.60` → `0.0.61`. Nothing else.

Contents released: [#102](https://github.com/pikacss/pikacss/pull/102) (dev-server class-name desync fix — the only change users of the published packages will notice), plus agent control-plane and CI work in #92, #93, #94, #101, #103, #104.