### PR TITLE
chore: release v0.0.61

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "demo",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"engines": {
 		"node": ">=22"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/docs",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"description": "Documents for pikacss.",
 	"author": "DevilTea <ch19980814@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pikacss-monorepo",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"packageManager": "pnpm@10.34.4",
 	"description": "The instant on-demand atomic css-in-js engine.",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/core",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/integration",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/nuxt-pikacss",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-design-tokens/package.json
+++ b/packages/plugin-design-tokens/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-fonts/package.json
+++ b/packages/plugin-fonts/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-icons/package.json
+++ b/packages/plugin-icons/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/plugin-icons",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-reset/package.json
+++ b/packages/plugin-reset/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/plugin-typography/package.json
+++ b/packages/plugin-typography/package.json
@@ -4,7 +4,7 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/unplugin-pikacss",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"author": "DevilTea <ch19980814@gmail.com>",
 	"license": "MIT",
 	"homepage": "https://pikacss.github.io",

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@pikacss/playground",
 	"type": "module",
-	"version": "0.0.60",
+	"version": "0.0.61",
 	"private": true,
 	"engines": {
 		"node": ">=22"


### PR DESCRIPTION
Version bump to `v0.0.61` from the `Bump version` workflow ([run 30283014727](https://github.com/pikacss/pikacss/actions/runs/30283014727)). `bumpp -r patch` across 14 manifests, `0.0.60` → `0.0.61`, nothing else.

**Merging this does not publish.** Publishing starts when the tag is pushed afterwards:

```bash
git switch main && git pull --ff-only
git tag v0.0.61 && git push origin v0.0.61
```

### What ships in this release

- [#102](https://github.com/pikacss/pikacss/pull/102) — **the only change users of the published packages will notice.** Fixes atomic class names silently resolving to another rule's styles after a config change in dev: a Vue SFC's `?vue&type=template` module kept serving names from the previous id generation against freshly regenerated CSS.

Everything else is repository infrastructure with no published surface: agent control plane and CI gates (#92, #93, #94, #101) and the release-flow rework (#103, #104, #106).

### First run of the new flow

This is also the first release under the three-step flow, so `release.yml` runs for the first time when the tag lands. It verifies the tag name matches the manifests and that the commit is on `main` before anything reaches npm.