### PR TITLE
docs: point contributors at the three-step release flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ typecheck). For cross-cutting changes, run the repo-wide `pnpm lint`,
 
 ## Publishing
 
-Publishing is maintainer-only and runs through the `Release` GitHub workflow
-(npm trusted publishing). See [MIGRATION.md](./MIGRATION.md) and
-[SUPPORT.md](./SUPPORT.md) for the versioning and support policy.
+Publishing is maintainer-only: a `Bump version` workflow run, a version pull
+request, and a hand-pushed tag that triggers the `Release` workflow (npm
+trusted publishing). [RELEASING.md](./RELEASING.md) has the walkthrough. See
+[MIGRATION.md](./MIGRATION.md) and [SUPPORT.md](./SUPPORT.md) for the
+versioning and support policy.


### PR DESCRIPTION
Last leftover from the release rework. `CONTRIBUTING.md` described publishing as a single `Release` workflow run, which stopped being true when the flow was split into bump → version pull request → hand-pushed tag. Names the three steps and links `RELEASING.md` instead of restating them.

Everything else from the rework is already cleaned up:

- The unused `release` deployment environment and its leftover required reviewer are gone (`pnpm setup:guardrails`); only `github-pages` remains.
- The `release` label is deleted — it existed only for the label-triggered publish design that was abandoned, is no longer applied by anything, and its description ("merging publishes to npm") had become wrong.
- No references to `release-prepare.yml` / `release-publish.yml` / the `release` environment survive anywhere in the tree.
- Branch protection verified intact after the guardrails run: `enforce_admins=true`, pull request required, 0 approvals, 7 required checks, force pushes blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)